### PR TITLE
feat: data export — CSV/Excel for Postgres/SQLite, JSON for MongoDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1748,7 @@ dependencies = [
  "based-storage",
  "based-workspace",
  "cargo-packager-updater",
+ "csv",
  "dirs 6.0.0",
  "env_logger",
  "futures",
@@ -1741,6 +1763,7 @@ dependencies = [
  "reqwest",
  "rfd",
  "rust-embed",
+ "rust_xlsxwriter",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -2218,6 +2241,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5950,6 +5974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_xlsxwriter"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f281b687352597d29efaad39701d1167d5c48aa76fb973e392bc13e9d44e7f36"
+dependencies = [
+ "zip",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7844,6 +7877,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -9852,6 +9891,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zlog"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#eb2223c0802c4e864caac1687631ac0c45af4dee"
@@ -9867,6 +9926,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "ztracing"

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -83,6 +83,8 @@ url = "2"
 toml.workspace = true
 notify.workspace = true
 rfd.workspace = true
+csv = "1"
+rust_xlsxwriter = "0"
 
 # DB engines — all three included so Phase 3/4/5 modules compile without
 # touching the workspace Cargo.toml again.

--- a/apps/desktop/src/mongodb/document_viewer.rs
+++ b/apps/desktop/src/mongodb/document_viewer.rs
@@ -258,14 +258,21 @@ impl Render for DocumentViewerPanel {
                             .on_click(move |_, _, cx| {
                                 let json = export::to_json(&export_headers, &export_rows);
                                 cx.spawn(async move |cx| {
-                                    let _ = export::save_bytes(
+                                    if let Some(path) = export::save_bytes(
                                         cx,
                                         "export.json",
                                         "JSON",
                                         &["json"],
                                         json.into_bytes(),
                                     )
-                                    .await;
+                                    .await
+                                    {
+                                        cx.update(|app| {
+                                            crate::workspace::notify::push_export_success(
+                                                app, &path,
+                                            )
+                                        });
+                                    }
                                 })
                                 .detach();
                             }),

--- a/apps/desktop/src/mongodb/document_viewer.rs
+++ b/apps/desktop/src/mongodb/document_viewer.rs
@@ -2,8 +2,8 @@
 
 use gpui::{prelude::*, *};
 use gpui_component::{
-    ActiveTheme,
-    button::Button,
+    ActiveTheme, Sizable as _,
+    button::{Button, ButtonVariants},
     dock::{Panel, PanelEvent},
     h_flex,
     menu::PopupMenu,
@@ -18,6 +18,7 @@ use gpui_component::table::TableEvent;
 
 use crate::widgets::cell_detail::{CellDetail, CellValue, interpret_cell_display};
 use crate::widgets::data_table::{configure_row_table, render_row_table};
+use crate::widgets::export;
 use crate::widgets::filter_bar::{FilterBar, FilterExpr};
 use crate::widgets::virtual_table::{RowDelegate, data_column, replace_table_data};
 
@@ -200,6 +201,23 @@ impl Render for DocumentViewerPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let border = cx.theme().border;
         let muted = cx.theme().muted_foreground;
+
+        let (export_headers, export_rows) = {
+            let st = self.table.read(cx);
+            let d = st.delegate();
+            let h = d
+                .columns
+                .iter()
+                .map(|c| c.key.to_string())
+                .collect::<Vec<_>>();
+            let r = d
+                .rows
+                .iter()
+                .map(|row| row.iter().map(|c| c.to_string()).collect())
+                .collect::<Vec<Vec<String>>>();
+            (h, r)
+        };
+
         v_flex()
             .relative()
             .size_full()
@@ -231,6 +249,26 @@ impl Render for DocumentViewerPanel {
                                 });
                                 p.reload(cx);
                             })),
+                    )
+                    .child(
+                        Button::new("mongo-export-json")
+                            .ghost()
+                            .small()
+                            .label("Export JSON")
+                            .on_click(move |_, _, cx| {
+                                let json = export::to_json(&export_headers, &export_rows);
+                                cx.spawn(async move |cx| {
+                                    let _ = export::save_bytes(
+                                        cx,
+                                        "export.json",
+                                        "JSON",
+                                        &["json"],
+                                        json.into_bytes(),
+                                    )
+                                    .await;
+                                })
+                                .detach();
+                            }),
                     )
                     .when(self.loading, |h| {
                         h.child(div().text_sm().text_color(muted).child("Loading…"))

--- a/apps/desktop/src/mongodb/pipeline_builder.rs
+++ b/apps/desktop/src/mongodb/pipeline_builder.rs
@@ -261,14 +261,21 @@ impl Render for PipelineBuilderPanel {
                             .on_click(move |_, _, cx| {
                                 let json = export::to_json(&export_headers, &export_rows);
                                 cx.spawn(async move |cx| {
-                                    let _ = export::save_bytes(
+                                    if let Some(path) = export::save_bytes(
                                         cx,
                                         "export.json",
                                         "JSON",
                                         &["json"],
                                         json.into_bytes(),
                                     )
-                                    .await;
+                                    .await
+                                    {
+                                        cx.update(|app| {
+                                            crate::workspace::notify::push_export_success(
+                                                app, &path,
+                                            )
+                                        });
+                                    }
                                 })
                                 .detach();
                             }),

--- a/apps/desktop/src/mongodb/pipeline_builder.rs
+++ b/apps/desktop/src/mongodb/pipeline_builder.rs
@@ -2,6 +2,7 @@
 
 use gpui::{prelude::*, *};
 use gpui_component::{
+    Sizable as _,
     button::{Button, ButtonVariants},
     dock::{Panel, PanelEvent},
     h_flex,
@@ -16,6 +17,7 @@ use mongodb::bson::Document;
 use crate::connection::ConnectionId;
 use crate::query_store::{HistoryEntry, QueryStore};
 use crate::widgets::data_table::{configure_row_table, render_row_table};
+use crate::widgets::export;
 use crate::widgets::sql_editor::{self, new_json_input, text_from_input};
 use crate::widgets::virtual_table::{RowDelegate, data_column, replace_table_data};
 
@@ -211,6 +213,22 @@ impl Panel for PipelineBuilderPanel {
 
 impl Render for PipelineBuilderPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let (export_headers, export_rows) = {
+            let st = self.result.read(cx);
+            let d = st.delegate();
+            let h = d
+                .columns
+                .iter()
+                .map(|c| c.key.to_string())
+                .collect::<Vec<_>>();
+            let r = d
+                .rows
+                .iter()
+                .map(|row| row.iter().map(|c| c.to_string()).collect())
+                .collect::<Vec<Vec<String>>>();
+            (h, r)
+        };
+
         v_flex()
             .size_full()
             .child(
@@ -234,6 +252,26 @@ impl Render for PipelineBuilderPanel {
                             .primary()
                             .label("Run pipeline")
                             .on_click(cx.listener(|p, _, _, cx| p.run(cx))),
+                    )
+                    .child(
+                        Button::new("mongo-pipe-export-json")
+                            .ghost()
+                            .small()
+                            .label("Export JSON")
+                            .on_click(move |_, _, cx| {
+                                let json = export::to_json(&export_headers, &export_rows);
+                                cx.spawn(async move |cx| {
+                                    let _ = export::save_bytes(
+                                        cx,
+                                        "export.json",
+                                        "JSON",
+                                        &["json"],
+                                        json.into_bytes(),
+                                    )
+                                    .await;
+                                })
+                                .detach();
+                            }),
                     )
                     .child(div().flex_1().text_sm().child(self.status.clone())),
             )

--- a/apps/desktop/src/postgres/data_viewer.rs
+++ b/apps/desktop/src/postgres/data_viewer.rs
@@ -264,16 +264,22 @@ impl Render for DataViewerPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hc, rc) = (hc.clone(), rc.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.csv",
                                                 "CSV",
                                                 &["csv"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),
@@ -286,16 +292,22 @@ impl Render for DataViewerPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hx, rx) = (hx.clone(), rx.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.xlsx",
                                                 "Excel",
                                                 &["xlsx"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/postgres/data_viewer.rs
+++ b/apps/desktop/src/postgres/data_viewer.rs
@@ -273,13 +273,13 @@ impl Render for DataViewerPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),
@@ -301,13 +301,13 @@ impl Render for DataViewerPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/postgres/data_viewer.rs
+++ b/apps/desktop/src/postgres/data_viewer.rs
@@ -2,11 +2,12 @@
 
 use gpui::{prelude::*, *};
 use gpui_component::{
-    ActiveTheme,
-    button::Button,
+    ActiveTheme, Sizable as _,
+    button::{Button, ButtonVariants},
     dock::{Panel, PanelEvent},
     h_flex,
     menu::PopupMenu,
+    popover::Popover,
     table::{Column, TableState},
     v_flex,
 };
@@ -17,6 +18,7 @@ use gpui_component::table::TableEvent;
 use crate::app::prefs;
 use crate::widgets::cell_detail::{CellDetail, CellValue, interpret_cell_display};
 use crate::widgets::data_table::{configure_row_table, render_row_table};
+use crate::widgets::export;
 use crate::widgets::filter_bar::FilterBar;
 use crate::widgets::pagination::{offset_for_page, sql_pagination_controls, sql_row_range_label};
 use crate::widgets::row_cell::pg_cell_display;
@@ -223,6 +225,84 @@ impl Render for DataViewerPanel {
         let muted = cx.theme().muted_foreground;
         let border = cx.theme().border;
 
+        let (export_headers, export_rows) = {
+            let st = self.table.read(cx);
+            let d = st.delegate();
+            let h = d
+                .columns
+                .iter()
+                .map(|c| c.key.to_string())
+                .collect::<Vec<_>>();
+            let r = d
+                .rows
+                .iter()
+                .map(|row| row.iter().map(|c| c.to_string()).collect())
+                .collect::<Vec<Vec<String>>>();
+            (h, r)
+        };
+        let export_popover = {
+            let (h, r) = (export_headers.clone(), export_rows.clone());
+            let (h2, r2) = (export_headers.clone(), export_rows.clone());
+            Popover::new("pg-dv-export-popover")
+                .trigger(
+                    Button::new("pg-dv-export-trigger")
+                        .ghost()
+                        .small()
+                        .label("Export"),
+                )
+                .content(move |_, _, _| {
+                    let (hc, rc) = (h.clone(), r.clone());
+                    let (hx, rx) = (h2.clone(), r2.clone());
+                    v_flex()
+                        .gap(px(2.0))
+                        .p(px(4.0))
+                        .child(
+                            Button::new("pg-dv-export-csv")
+                                .ghost()
+                                .small()
+                                .label("CSV")
+                                .on_click(move |_, _, cx| {
+                                    let (hc, rc) = (hc.clone(), rc.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.csv",
+                                                "CSV",
+                                                &["csv"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                        .child(
+                            Button::new("pg-dv-export-xlsx")
+                                .ghost()
+                                .small()
+                                .label("Excel (.xlsx)")
+                                .on_click(move |_, _, cx| {
+                                    let (hx, rx) = (hx.clone(), rx.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.xlsx",
+                                                "Excel",
+                                                &["xlsx"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                })
+        };
+
         let toolbar = h_flex()
             .w_full()
             .px(px(8.0))
@@ -251,6 +331,7 @@ impl Render for DataViewerPanel {
                         panel.load_page(0, cx);
                     })),
             )
+            .child(export_popover)
             .child(div().flex_1())
             .when(loading, |d| {
                 d.child(div().text_sm().text_color(muted).child("Loading…"))

--- a/apps/desktop/src/postgres/query_editor.rs
+++ b/apps/desktop/src/postgres/query_editor.rs
@@ -594,13 +594,13 @@ impl Render for QueryEditorPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),
@@ -622,13 +622,13 @@ impl Render for QueryEditorPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/postgres/query_editor.rs
+++ b/apps/desktop/src/postgres/query_editor.rs
@@ -585,16 +585,22 @@ impl Render for QueryEditorPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hc, rc) = (hc.clone(), rc.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.csv",
                                                 "CSV",
                                                 &["csv"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),
@@ -607,16 +613,22 @@ impl Render for QueryEditorPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hx, rx) = (hx.clone(), rx.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.xlsx",
                                                 "Excel",
                                                 &["xlsx"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/postgres/query_editor.rs
+++ b/apps/desktop/src/postgres/query_editor.rs
@@ -10,6 +10,7 @@ use gpui_component::{
     h_flex,
     input::{InputEvent, InputState},
     menu::PopupMenu,
+    popover::Popover,
     resizable::{ResizableState, resizable_panel, v_resizable},
     scroll::ScrollableElement as _,
     spinner::Spinner,
@@ -23,6 +24,7 @@ use crate::postgres::execute_sql;
 use crate::postgres::explain_plan::{PlanNode, parse_pg_explain_json, render_plan_node};
 use crate::query_store::{HistoryEntry, QueryStore};
 use crate::widgets::data_table::{configure_row_table, render_row_table};
+use crate::widgets::export;
 use crate::widgets::query_panel_extras;
 use crate::widgets::result_tabs::{BottomTab, result_tab_strip};
 use crate::widgets::sql_editor::{self, new_sql_input, set_input_text, text_from_input};
@@ -544,6 +546,84 @@ impl Render for QueryEditorPanel {
         let var_map = cx.global::<crate::project::ProjectVars>().vars.clone();
         let mono_font = cx.theme().mono_font_family.clone();
 
+        let (export_headers, export_rows) = {
+            let st = self.result.read(cx);
+            let d = st.delegate();
+            let h = d
+                .columns
+                .iter()
+                .map(|c| c.key.to_string())
+                .collect::<Vec<_>>();
+            let r = d
+                .rows
+                .iter()
+                .map(|row| row.iter().map(|c| c.to_string()).collect())
+                .collect::<Vec<Vec<String>>>();
+            (h, r)
+        };
+        let export_popover = {
+            let (h, r) = (export_headers.clone(), export_rows.clone());
+            let (h2, r2) = (export_headers.clone(), export_rows.clone());
+            Popover::new("pg-export-popover")
+                .trigger(
+                    Button::new("pg-export-trigger")
+                        .ghost()
+                        .small()
+                        .label("Export"),
+                )
+                .content(move |_, _, _| {
+                    let (hc, rc) = (h.clone(), r.clone());
+                    let (hx, rx) = (h2.clone(), r2.clone());
+                    v_flex()
+                        .gap(px(2.0))
+                        .p(px(4.0))
+                        .child(
+                            Button::new("pg-export-csv")
+                                .ghost()
+                                .small()
+                                .label("CSV")
+                                .on_click(move |_, _, cx| {
+                                    let (hc, rc) = (hc.clone(), rc.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.csv",
+                                                "CSV",
+                                                &["csv"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                        .child(
+                            Button::new("pg-export-xlsx")
+                                .ghost()
+                                .small()
+                                .label("Excel (.xlsx)")
+                                .on_click(move |_, _, cx| {
+                                    let (hx, rx) = (hx.clone(), rx.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.xlsx",
+                                                "Excel",
+                                                &["xlsx"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                })
+        };
+
         let toolbar = h_flex()
             .gap(px(6.0))
             .px_2()
@@ -575,6 +655,7 @@ impl Render for QueryEditorPanel {
                 mono_font,
                 cx,
             ))
+            .child(export_popover)
             .child(div().flex_1())
             .child(render_status_cluster(&self.status, cx));
 

--- a/apps/desktop/src/sqlite/data_viewer.rs
+++ b/apps/desktop/src/sqlite/data_viewer.rs
@@ -2,11 +2,12 @@
 
 use gpui::{prelude::*, *};
 use gpui_component::{
-    ActiveTheme,
-    button::Button,
+    ActiveTheme, Sizable as _,
+    button::{Button, ButtonVariants},
     dock::{Panel, PanelEvent},
     h_flex,
     menu::PopupMenu,
+    popover::Popover,
     table::{Column, TableState},
     v_flex,
 };
@@ -17,6 +18,7 @@ use gpui_component::table::TableEvent;
 use crate::app::prefs;
 use crate::widgets::cell_detail::{CellDetail, CellValue, interpret_cell_display};
 use crate::widgets::data_table::{configure_row_table, render_row_table};
+use crate::widgets::export;
 use crate::widgets::filter_bar::FilterBar;
 use crate::widgets::pagination::sql_page_state;
 use crate::widgets::pagination::{offset_for_page, sql_pagination_controls, sql_row_range_label};
@@ -228,6 +230,84 @@ impl Render for DataViewerPanel {
         let muted = cx.theme().muted_foreground;
         let border = cx.theme().border;
 
+        let (export_headers, export_rows) = {
+            let st = self.table.read(cx);
+            let d = st.delegate();
+            let h = d
+                .columns
+                .iter()
+                .map(|c| c.key.to_string())
+                .collect::<Vec<_>>();
+            let r = d
+                .rows
+                .iter()
+                .map(|row| row.iter().map(|c| c.to_string()).collect())
+                .collect::<Vec<Vec<String>>>();
+            (h, r)
+        };
+        let export_popover = {
+            let (h, r) = (export_headers.clone(), export_rows.clone());
+            let (h2, r2) = (export_headers.clone(), export_rows.clone());
+            Popover::new("sqlite-dv-export-popover")
+                .trigger(
+                    Button::new("sqlite-dv-export-trigger")
+                        .ghost()
+                        .small()
+                        .label("Export"),
+                )
+                .content(move |_, _, _| {
+                    let (hc, rc) = (h.clone(), r.clone());
+                    let (hx, rx) = (h2.clone(), r2.clone());
+                    v_flex()
+                        .gap(px(2.0))
+                        .p(px(4.0))
+                        .child(
+                            Button::new("sqlite-dv-export-csv")
+                                .ghost()
+                                .small()
+                                .label("CSV")
+                                .on_click(move |_, _, cx| {
+                                    let (hc, rc) = (hc.clone(), rc.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.csv",
+                                                "CSV",
+                                                &["csv"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                        .child(
+                            Button::new("sqlite-dv-export-xlsx")
+                                .ghost()
+                                .small()
+                                .label("Excel (.xlsx)")
+                                .on_click(move |_, _, cx| {
+                                    let (hx, rx) = (hx.clone(), rx.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.xlsx",
+                                                "Excel",
+                                                &["xlsx"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                })
+        };
+
         let toolbar = h_flex()
             .w_full()
             .px(px(8.0))
@@ -256,6 +336,7 @@ impl Render for DataViewerPanel {
                         panel.load_page(0, cx);
                     })),
             )
+            .child(export_popover)
             .child(div().flex_1())
             .when(loading, |d| {
                 d.child(div().text_sm().text_color(muted).child("Loading…"))

--- a/apps/desktop/src/sqlite/data_viewer.rs
+++ b/apps/desktop/src/sqlite/data_viewer.rs
@@ -269,16 +269,22 @@ impl Render for DataViewerPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hc, rc) = (hc.clone(), rc.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.csv",
                                                 "CSV",
                                                 &["csv"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),
@@ -291,16 +297,22 @@ impl Render for DataViewerPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hx, rx) = (hx.clone(), rx.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.xlsx",
                                                 "Excel",
                                                 &["xlsx"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/sqlite/data_viewer.rs
+++ b/apps/desktop/src/sqlite/data_viewer.rs
@@ -278,13 +278,13 @@ impl Render for DataViewerPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),
@@ -306,13 +306,13 @@ impl Render for DataViewerPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/sqlite/query_editor.rs
+++ b/apps/desktop/src/sqlite/query_editor.rs
@@ -10,6 +10,7 @@ use gpui_component::{
     h_flex,
     input::{InputEvent, InputState},
     menu::PopupMenu,
+    popover::Popover,
     resizable::{ResizableState, resizable_panel, v_resizable},
     spinner::Spinner,
     table::{Column, TableState},
@@ -24,6 +25,7 @@ use crate::connection::ConnectionId;
 use crate::db;
 use crate::query_store::{HistoryEntry, QueryStore};
 use crate::widgets::data_table::{configure_row_table, render_row_table};
+use crate::widgets::export;
 use crate::widgets::query_panel_extras;
 use crate::widgets::result_tabs::{BottomTab, result_tab_strip};
 use crate::widgets::row_cell::sqlite_cell_display;
@@ -497,6 +499,84 @@ impl Render for QueryEditorPanel {
         let var_map = cx.global::<crate::project::ProjectVars>().vars.clone();
         let mono_font = cx.theme().mono_font_family.clone();
 
+        let (export_headers, export_rows) = {
+            let st = self.result.read(cx);
+            let d = st.delegate();
+            let h = d
+                .columns
+                .iter()
+                .map(|c| c.key.to_string())
+                .collect::<Vec<_>>();
+            let r = d
+                .rows
+                .iter()
+                .map(|row| row.iter().map(|c| c.to_string()).collect())
+                .collect::<Vec<Vec<String>>>();
+            (h, r)
+        };
+        let export_popover = {
+            let (h, r) = (export_headers.clone(), export_rows.clone());
+            let (h2, r2) = (export_headers.clone(), export_rows.clone());
+            Popover::new("sqlite-export-popover")
+                .trigger(
+                    Button::new("sqlite-export-trigger")
+                        .ghost()
+                        .small()
+                        .label("Export"),
+                )
+                .content(move |_, _, _| {
+                    let (hc, rc) = (h.clone(), r.clone());
+                    let (hx, rx) = (h2.clone(), r2.clone());
+                    v_flex()
+                        .gap(px(2.0))
+                        .p(px(4.0))
+                        .child(
+                            Button::new("sqlite-export-csv")
+                                .ghost()
+                                .small()
+                                .label("CSV")
+                                .on_click(move |_, _, cx| {
+                                    let (hc, rc) = (hc.clone(), rc.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.csv",
+                                                "CSV",
+                                                &["csv"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                        .child(
+                            Button::new("sqlite-export-xlsx")
+                                .ghost()
+                                .small()
+                                .label("Excel (.xlsx)")
+                                .on_click(move |_, _, cx| {
+                                    let (hx, rx) = (hx.clone(), rx.clone());
+                                    cx.spawn(async move |cx| {
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
+                                            let _ = export::save_bytes(
+                                                cx,
+                                                "export.xlsx",
+                                                "Excel",
+                                                &["xlsx"],
+                                                bytes,
+                                            )
+                                            .await;
+                                        }
+                                    })
+                                    .detach();
+                                }),
+                        )
+                })
+        };
+
         let toolbar = h_flex()
             .gap(px(6.0))
             .px_2()
@@ -528,6 +608,7 @@ impl Render for QueryEditorPanel {
                 mono_font,
                 cx,
             ))
+            .child(export_popover)
             .child(div().flex_1())
             .child(render_status_cluster(&self.status, cx));
 

--- a/apps/desktop/src/sqlite/query_editor.rs
+++ b/apps/desktop/src/sqlite/query_editor.rs
@@ -538,16 +538,22 @@ impl Render for QueryEditorPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hc, rc) = (hc.clone(), rc.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_csv(&hc, &rc) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_csv(&hc, &rc)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.csv",
                                                 "CSV",
                                                 &["csv"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),
@@ -560,16 +566,22 @@ impl Render for QueryEditorPanel {
                                 .on_click(move |_, _, cx| {
                                     let (hx, rx) = (hx.clone(), rx.clone());
                                     cx.spawn(async move |cx| {
-                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx) {
-                                            let _ = export::save_bytes(
+                                        if let Ok(bytes) = export::to_xlsx(&hx, &rx)
+                                            && let Some(path) = export::save_bytes(
                                                 cx,
                                                 "export.xlsx",
                                                 "Excel",
                                                 &["xlsx"],
                                                 bytes,
                                             )
-                                            .await;
-                                        }
+                                            .await
+                                            {
+                                                cx.update(|app| {
+                                                    crate::workspace::notify::push_export_success(
+                                                        app, &path,
+                                                    )
+                                                });
+                                            }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/sqlite/query_editor.rs
+++ b/apps/desktop/src/sqlite/query_editor.rs
@@ -547,13 +547,13 @@ impl Render for QueryEditorPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),
@@ -575,13 +575,13 @@ impl Render for QueryEditorPanel {
                                                 bytes,
                                             )
                                             .await
-                                            {
-                                                cx.update(|app| {
-                                                    crate::workspace::notify::push_export_success(
-                                                        app, &path,
-                                                    )
-                                                });
-                                            }
+                                        {
+                                            cx.update(|app| {
+                                                crate::workspace::notify::push_export_success(
+                                                    app, &path,
+                                                )
+                                            });
+                                        }
                                     })
                                     .detach();
                                 }),

--- a/apps/desktop/src/widgets/export.rs
+++ b/apps/desktop/src/widgets/export.rs
@@ -1,0 +1,139 @@
+// widgets/export.rs — serialise RowDelegate snapshots to CSV, Excel, or JSON
+// and save them to a user-chosen path via an rfd save-file dialog.
+
+use anyhow::Context as _;
+use gpui::AsyncApp;
+use rust_xlsxwriter::{Format, Workbook};
+
+use crate::widgets::virtual_table::NULL_CELL_DISPLAY;
+
+// ── Serialisers ──────────────────────────────────────────────────────────────
+
+/// Serialise tabular data to CSV bytes.
+///
+/// Cells that display as `"NULL"` (or are empty) are written as empty fields
+/// so spreadsheet tools don't receive the literal string "NULL".
+pub fn to_csv(headers: &[String], rows: &[Vec<String>]) -> anyhow::Result<Vec<u8>> {
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    wtr.write_record(headers)?;
+    for row in rows {
+        let cells: Vec<&str> = row
+            .iter()
+            .map(|c| {
+                if c.is_empty() || c == NULL_CELL_DISPLAY {
+                    ""
+                } else {
+                    c.as_str()
+                }
+            })
+            .collect();
+        wtr.write_record(&cells)?;
+    }
+    wtr.into_inner().context("csv flush")
+}
+
+/// Serialise tabular data to an `.xlsx` workbook buffer.
+///
+/// Row 0 is a bold header row; data starts at row 1. NULL cells are written
+/// as empty strings.
+pub fn to_xlsx(headers: &[String], rows: &[Vec<String>]) -> anyhow::Result<Vec<u8>> {
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+
+    let bold = Format::new().set_bold();
+    for (col_ix, header) in headers.iter().enumerate() {
+        sheet
+            .write_with_format(0, col_ix as u16, header.as_str(), &bold)
+            .context("write header")?;
+    }
+
+    for (row_ix, row) in rows.iter().enumerate() {
+        for (col_ix, cell) in row.iter().enumerate() {
+            let val = if cell.is_empty() || cell == NULL_CELL_DISPLAY {
+                ""
+            } else {
+                cell.as_str()
+            };
+            sheet
+                .write(row_ix as u32 + 1, col_ix as u16, val)
+                .context("write cell")?;
+        }
+    }
+
+    workbook.save_to_buffer().context("save xlsx buffer")
+}
+
+/// Serialise tabular data to a pretty-printed JSON array of objects.
+///
+/// Cells that display as `"NULL"` (or are empty) are written as
+/// `null` values rather than the string `"NULL"`.
+pub fn to_json(headers: &[String], rows: &[Vec<String>]) -> String {
+    let arr: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|row| {
+            let mut obj = serde_json::Map::new();
+            for (col_ix, header) in headers.iter().enumerate() {
+                let val = match row.get(col_ix) {
+                    Some(c) if !c.is_empty() && c != NULL_CELL_DISPLAY => {
+                        serde_json::Value::String(c.clone())
+                    }
+                    _ => serde_json::Value::Null,
+                };
+                obj.insert(header.clone(), val);
+            }
+            serde_json::Value::Object(obj)
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&serde_json::Value::Array(arr)).unwrap_or_default()
+}
+
+// ── File dialog + write ───────────────────────────────────────────────────────
+
+/// Open a native save-file dialog, then write `bytes` to the chosen path.
+///
+/// Both the dialog and the write run inside `spawn_blocking` on Tokio's thread
+/// pool — the same pattern as `project/pick.rs`.  Using `std::fs::write` (not
+/// `tokio::fs::write`) is correct here because we're already on a blocking
+/// thread.  The extension from `extensions[0]` is appended to the path if the
+/// platform didn't include it (e.g. Linux GTK dialogs).
+///
+/// Returns `Ok(())` whether the user cancels or the write succeeds.
+pub async fn save_bytes(
+    cx: &mut AsyncApp,
+    filename: &str,
+    filter_name: &str,
+    extensions: &[&str],
+    bytes: Vec<u8>,
+) -> anyhow::Result<()> {
+    let fname = filename.to_string();
+    let filter = filter_name.to_string();
+    let exts: Vec<String> = extensions.iter().map(|s| s.to_string()).collect();
+
+    crate::db::run_infallible(cx, async move {
+        tokio::task::spawn_blocking(move || {
+            let exts_ref: Vec<&str> = exts.iter().map(String::as_str).collect();
+            let Some(mut path) = rfd::FileDialog::new()
+                .set_file_name(&fname)
+                .add_filter(&filter, &exts_ref)
+                .save_file()
+            else {
+                return; // user cancelled
+            };
+
+            // Ensure the chosen path carries the right extension.
+            if let Some(expected) = exts_ref.first()
+                && path.extension().and_then(|e| e.to_str()) != Some(expected) {
+                    path.set_extension(expected);
+                }
+
+            let _ = std::fs::write(&path, &bytes);
+        })
+        .await
+        .ok()
+    })
+    .await
+    .ok();
+
+    Ok(())
+}

--- a/apps/desktop/src/widgets/export.rs
+++ b/apps/desktop/src/widgets/export.rs
@@ -90,50 +90,55 @@ pub fn to_json(headers: &[String], rows: &[Vec<String>]) -> String {
 
 // ── File dialog + write ───────────────────────────────────────────────────────
 
-/// Open a native save-file dialog, then write `bytes` to the chosen path.
+/// Open a native save-file dialog, write `bytes` to the chosen path, and
+/// return the saved path.
 ///
 /// Both the dialog and the write run inside `spawn_blocking` on Tokio's thread
-/// pool — the same pattern as `project/pick.rs`.  Using `std::fs::write` (not
+/// pool — the same pattern as `project/pick.rs`. Using `std::fs::write` (not
 /// `tokio::fs::write`) is correct here because we're already on a blocking
-/// thread.  The extension from `extensions[0]` is appended to the path if the
-/// platform didn't include it (e.g. Linux GTK dialogs).
+/// thread. The extension from `extensions[0]` is appended if the platform
+/// omitted it (e.g. Linux GTK dialogs).
 ///
-/// Returns `Ok(())` whether the user cancels or the write succeeds.
+/// Returns `None` if the user cancelled or the write failed.
 pub async fn save_bytes(
     cx: &mut AsyncApp,
     filename: &str,
     filter_name: &str,
     extensions: &[&str],
     bytes: Vec<u8>,
-) -> anyhow::Result<()> {
+) -> Option<std::path::PathBuf> {
     let fname = filename.to_string();
     let filter = filter_name.to_string();
     let exts: Vec<String> = extensions.iter().map(|s| s.to_string()).collect();
 
     crate::db::run_infallible(cx, async move {
-        tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || -> Option<std::path::PathBuf> {
             let exts_ref: Vec<&str> = exts.iter().map(String::as_str).collect();
             let Some(mut path) = rfd::FileDialog::new()
                 .set_file_name(&fname)
                 .add_filter(&filter, &exts_ref)
                 .save_file()
             else {
-                return; // user cancelled
+                return None; // user cancelled
             };
 
-            // Ensure the chosen path carries the right extension.
+            // Enforce the extension if the platform omitted it.
             if let Some(expected) = exts_ref.first()
                 && path.extension().and_then(|e| e.to_str()) != Some(expected) {
                     path.set_extension(expected);
                 }
 
-            let _ = std::fs::write(&path, &bytes);
+            if std::fs::write(&path, &bytes).is_ok() {
+                Some(path)
+            } else {
+                None
+            }
         })
         .await
         .ok()
+        .flatten()
     })
     .await
-    .ok();
-
-    Ok(())
+    .ok()
+    .flatten()
 }

--- a/apps/desktop/src/widgets/export.rs
+++ b/apps/desktop/src/widgets/export.rs
@@ -124,9 +124,10 @@ pub async fn save_bytes(
 
             // Enforce the extension if the platform omitted it.
             if let Some(expected) = exts_ref.first()
-                && path.extension().and_then(|e| e.to_str()) != Some(expected) {
-                    path.set_extension(expected);
-                }
+                && path.extension().and_then(|e| e.to_str()) != Some(expected)
+            {
+                path.set_extension(expected);
+            }
 
             if std::fs::write(&path, &bytes).is_ok() {
                 Some(path)

--- a/apps/desktop/src/widgets/mod.rs
+++ b/apps/desktop/src/widgets/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod cell_detail;
 pub mod data_table;
+pub mod export;
 pub mod filter_bar;
 pub mod list_row;
 pub mod pagination;

--- a/apps/desktop/src/workspace/notify.rs
+++ b/apps/desktop/src/workspace/notify.rs
@@ -1,7 +1,12 @@
 //! VS Code–style tray notifications via `WindowExt::push_notification` (see Phase 7 UI feedback doc).
 
-use gpui::{App, SharedString};
-use gpui_component::{WindowExt, notification::Notification};
+use gpui::{App, IntoElement, SharedString, prelude::*, px};
+use gpui_component::{
+    Sizable as _, WindowExt,
+    button::{Button, ButtonVariants as _},
+    h_flex,
+    notification::Notification,
+};
 
 /// Push a notification on the **active** window’s `Root`. No-op if there is no active window.
 pub fn push_notification(app: &mut App, note: Notification) {
@@ -52,6 +57,98 @@ pub fn push_update_available(app: &mut App, version: &str) {
         ))
         .title("Update available"),
     );
+}
+
+/// Show a success toast after a file export.
+///
+/// Two explicit buttons are shown inside the notification body:
+/// - "Open file" — opens the file with the system default handler
+/// - "Show in Finder" / "Show in Explorer" / "Open Folder" — reveals it in the file manager
+///
+/// The notification body itself is not clickable; all actions are opt-in.
+pub fn push_export_success(app: &mut App, path: &std::path::Path) {
+    let file_name: SharedString = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("file")
+        .to_string()
+        .into();
+
+    let path_for_open = path.to_path_buf();
+    let path_for_reveal = path.to_path_buf();
+
+    #[cfg(target_os = "macos")]
+    let reveal_label: SharedString = "Show in Finder".into();
+    #[cfg(target_os = "windows")]
+    let reveal_label: SharedString = "Show in Explorer".into();
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let reveal_label: SharedString = "Open Folder".into();
+
+    let note = Notification::success(file_name)
+        .title("Export complete")
+        .autohide(false)
+        .content(move |_, _, _| {
+            let p_open = path_for_open.clone();
+            let p_reveal = path_for_reveal.clone();
+            let label = reveal_label.clone();
+            h_flex()
+                .gap(px(4.0))
+                .pt(px(4.0))
+                .child(
+                    Button::new("export-open-file")
+                        .ghost()
+                        .small()
+                        .label("Open file")
+                        .on_click(move |_, _, _| {
+                            open_path(&p_open);
+                        }),
+                )
+                .child(
+                    Button::new("export-reveal")
+                        .ghost()
+                        .small()
+                        .label(label)
+                        .on_click(move |_, _, _| {
+                            reveal_path(&p_reveal);
+                        }),
+                )
+                .into_any_element()
+        });
+
+    push_notification(app, note);
+}
+
+/// Open a file with the system default handler.
+fn open_path(path: &std::path::Path) {
+    #[cfg(target_os = "macos")]
+    let _ = std::process::Command::new("open").arg(path).spawn();
+    #[cfg(target_os = "linux")]
+    let _ = std::process::Command::new("xdg-open").arg(path).spawn();
+    #[cfg(target_os = "windows")]
+    {
+        let path_str = path.display().to_string();
+        let _ = std::process::Command::new("cmd")
+            .args(["/C", "start", "", &path_str])
+            .spawn();
+    }
+}
+
+/// Reveal a file in the platform file manager (Finder / Files / Explorer).
+fn reveal_path(path: &std::path::Path) {
+    #[cfg(target_os = "macos")]
+    let _ = std::process::Command::new("open")
+        .args(["-R", &path.display().to_string()])
+        .spawn();
+    #[cfg(target_os = "linux")]
+    {
+        let dir = path.parent().unwrap_or(path);
+        let _ = std::process::Command::new("xdg-open").arg(dir).spawn();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let arg = format!("/select,{}", path.display());
+        let _ = std::process::Command::new("explorer.exe").arg(&arg).spawn();
+    }
 }
 
 /// First line, capped — for sidebar / inline summaries. Full text lives in tooltips.


### PR DESCRIPTION
## Summary

- Adds **CSV** and **Excel (.xlsx)** export to all Postgres and SQLite query editors and data viewers via an **Export** toolbar popover
- Adds **JSON** export to MongoDB document viewer and pipeline builder
- New `widgets/export.rs` module handles serialisation (`csv` + `rust_xlsxwriter` + `serde_json`) and the native save-file dialog (`rfd`)
- After a successful save, a **success toast** fires with two explicit action buttons: **Open file** and **Show in Finder / Show in Explorer / Open Folder**
- No implicit click-to-open on the notification body; `autohide` is disabled so the user has time to act

## Test plan

- [ ] Run a query in the Postgres/SQLite query editor → click **Export** → save as CSV and verify the file opens correctly in a spreadsheet app
- [ ] Save as Excel (.xlsx) and verify bold headers + data rows
- [ ] Browse a table in the data viewer → export CSV/Excel
- [ ] Run a MongoDB aggregation pipeline → export JSON and verify array-of-objects structure with `null` for missing/NULL values
- [ ] Verify the success toast appears after each export with both **Open file** and **Show in Finder** buttons working correctly
- [ ] Cancel the save dialog → confirm no toast is shown

Made with [Cursor](https://cursor.com)