### PR TITLE
Add SSH tunnel for Postgres connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +137,20 @@ dependencies = [
  "cipher",
  "cpufeatures 0.2.17",
  "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -285,6 +309,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
 ]
 
 [[package]]
@@ -642,6 +678,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +715,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base62"
@@ -679,6 +745,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "based-core"
@@ -706,6 +778,7 @@ name = "based-postgres"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
+ "based-core",
  "serde",
  "serde_json",
  "sqlx",
@@ -750,6 +823,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "based-ssh"
+version = "0.0.0-dev"
+dependencies = [
+ "anyhow",
+ "based-core",
+ "dirs 6.0.0",
+ "log",
+ "rand_core 0.6.4",
+ "russh",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "based-storage"
 version = "0.0.0-dev"
 dependencies = [
@@ -779,6 +866,17 @@ dependencies = [
  "serde_json",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.12.2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -859,6 +957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1027,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -1156,6 +1273,17 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -1199,6 +1327,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1336,6 +1473,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -1620,6 +1763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,12 +1835,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1767,6 +1958,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +2056,7 @@ dependencies = [
  "based-project",
  "based-query",
  "based-sqlite",
+ "based-ssh",
  "based-storage",
  "based-workspace",
  "cargo-packager-updater",
@@ -1882,6 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1893,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -2024,12 +2239,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf 0.12.4",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2097,6 +2372,18 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2295,6 +2582,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2950,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2692,6 +3002,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3270,6 +3590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3727,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hexf-parse"
@@ -3858,6 +4195,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.11+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.12.1",
+ "num-bigint-dig 0.8.6",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha1 0.10.7",
+ "sha2 0.10.9",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4491,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.9",
+]
 
 [[package]]
 name = "leak"
@@ -4473,6 +4841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "media"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#bc538def4545534201bbfcac4e95ac34ea6501b6"
@@ -4675,6 +5049,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no_std_io2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4805,6 +5191,23 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -5275,7 +5678,7 @@ dependencies = [
  "hmac 0.12.1",
  "md-5 0.10.6",
  "num",
- "num-bigint-dig",
+ "num-bigint-dig 0.9.1",
  "pbkdf2 0.12.2",
  "serde",
  "serde_bytes",
@@ -5286,6 +5689,12 @@ dependencies = [
  "zeroize",
  "zvariant",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -5329,6 +5738,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pageant"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb28bd89a207e5cad59072ac4b364b08459d05f90ccfbcdaa920a95857d94430"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.7",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows 0.59.0",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5355,6 +5819,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -5405,6 +5880,15 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5548,6 +6032,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2 0.12.2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5606,12 +6128,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polycool"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5690,6 +6235,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5901,7 +6455,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -6274,6 +6828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,7 +6880,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6342,6 +6906,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig 0.8.6",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.54.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3ee9363fcf66d434d8015d9ae7d879681206981534c21bfdff8a7e34f52cca"
+dependencies = [
+ "aes",
+ "aws-lc-rs",
+ "base64ct",
+ "bitflags 2.13.1",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac 0.12.1",
+ "home",
+ "inout",
+ "internal-russh-forked-ssh-key",
+ "log",
+ "md5",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2 0.12.2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1 0.10.7",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
+dependencies = [
+ "libc",
+ "log",
+ "nix",
+ "ssh-encoding",
+ "winapi",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -6582,7 +7255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6593,7 +7266,7 @@ checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6625,6 +7298,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -6721,13 +7403,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6735,6 +7428,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -6959,6 +7666,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -7034,6 +7752,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7185,6 +7913,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7292,7 +8030,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
  "thiserror 2.0.20",
@@ -7359,6 +8097,35 @@ dependencies = [
  "time",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20 0.9.1",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8486,6 +9253,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,6 +9986,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -9284,6 +10077,19 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -9346,6 +10152,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/based-project",
     "crates/based-query",
     "crates/based-sqlite",
+    "crates/based-ssh",
     "crates/based-storage",
     "crates/based-workspace",
 ]
@@ -50,6 +51,7 @@ dirs = "6"
 tempfile = "3"
 rfd = "0.15"
 mongodb = { version = "2", features = ["tokio-runtime"] }
+russh = "0.54"
 
 [workspace.lints.clippy]
 # Upgrade all default-warn groups to errors.

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -60,6 +60,7 @@ based-project = { path = "../../crates/based-project" }
 based-query = { path = "../../crates/based-query" }
 based-postgres = { path = "../../crates/based-postgres" }
 based-sqlite = { path = "../../crates/based-sqlite" }
+based-ssh = { path = "../../crates/based-ssh" }
 based-storage = { path = "../../crates/based-storage" }
 based-workspace = { path = "../../crates/based-workspace" }
 

--- a/apps/desktop/src/connection/mod.rs
+++ b/apps/desktop/src/connection/mod.rs
@@ -8,6 +8,7 @@ pub mod descriptor;
 pub mod lifecycle;
 pub mod open;
 pub mod registry;
+pub mod tunnel;
 
 pub use descriptor::EngineRegistry;
 

--- a/apps/desktop/src/connection/tunnel.rs
+++ b/apps/desktop/src/connection/tunnel.rs
@@ -1,0 +1,53 @@
+//! Optional SSH hop in front of a TCP database endpoint.
+
+use anyhow::{Result, bail};
+use based_core::SshTunnelConfig;
+use based_ssh::{SshTunnel, open_tunnel};
+
+use crate::postgres::SslMode;
+
+pub fn ssh_hostname_verify_supported(ssl_mode: SslMode) -> Result<()> {
+    match ssl_mode {
+        SslMode::VerifyCa | SslMode::VerifyFull => {
+            bail!("SSH tunnel: hostname verify is not supported through SSH yet; use SSL require")
+        }
+        _ => Ok(()),
+    }
+}
+
+pub async fn open_optional_tunnel(
+    ssh: Option<&SshTunnelConfig>,
+    remote_host: &str,
+    remote_port: u16,
+    ssl_mode: SslMode,
+) -> Result<Option<SshTunnel>> {
+    let Some(ssh) = ssh else {
+        return Ok(None);
+    };
+    ssh_hostname_verify_supported(ssl_mode)?;
+    Ok(Some(open_tunnel(ssh, remote_host, remote_port).await?))
+}
+
+pub fn rewrite_tcp_endpoint(host: &mut String, port: &mut u16, tunnel: &SshTunnel) {
+    *host = "127.0.0.1".into();
+    *port = tunnel.local_port();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_and_disable_are_supported() {
+        ssh_hostname_verify_supported(SslMode::Disable).unwrap();
+        ssh_hostname_verify_supported(SslMode::Prefer).unwrap();
+        ssh_hostname_verify_supported(SslMode::Require).unwrap();
+    }
+
+    #[test]
+    fn verify_modes_are_rejected() {
+        let err = ssh_hostname_verify_supported(SslMode::VerifyFull).unwrap_err();
+        assert!(err.to_string().contains("hostname verify"));
+        assert!(ssh_hostname_verify_supported(SslMode::VerifyCa).is_err());
+    }
+}

--- a/apps/desktop/src/postgres/mod.rs
+++ b/apps/desktop/src/postgres/mod.rs
@@ -17,17 +17,38 @@ pub use based_postgres::{
 };
 
 use sqlx::PgPool;
-use sqlx::postgres::PgPoolOptions;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use crate::connection::lifecycle::{Connectable, TestReport};
+use crate::connection::tunnel::{open_optional_tunnel, rewrite_tcp_endpoint};
 use crate::db;
+use based_ssh::SshTunnel;
 use gpui_tokio::Tokio;
 
 /// Live Postgres connection wrapping a sqlx pool.
 pub struct PgConnection {
+    tunnel: Option<SshTunnel>,
     pub config: PostgresConfig,
-    pub pool: PgPool,
     pub server_version: Option<String>,
+    pub pool: PgPool,
+}
+
+async fn connect_opts(
+    config: &PostgresConfig,
+) -> anyhow::Result<(PgConnectOptions, Option<SshTunnel>, PostgresConfig)> {
+    let stored = config.clone();
+    let tunnel = open_optional_tunnel(
+        config.ssh.as_ref(),
+        &config.host,
+        config.port,
+        config.ssl_mode,
+    )
+    .await?;
+    let mut connect = config.clone();
+    if let Some(tunnel) = &tunnel {
+        rewrite_tcp_endpoint(&mut connect.host, &mut connect.port, tunnel);
+    }
+    Ok((pg_connect_options(&connect), tunnel, stored))
 }
 
 impl Connectable for PgConnection {
@@ -35,7 +56,7 @@ impl Connectable for PgConnection {
 
     fn open(config: Self::Config, cx: &mut App) -> Task<anyhow::Result<Self>> {
         Tokio::spawn_result(cx, async move {
-            let opts = pg_connect_options(&config);
+            let (opts, tunnel, stored) = connect_opts(&config).await?;
             let pool = PgPoolOptions::new()
                 .max_connections(8)
                 .connect_with(opts)
@@ -45,7 +66,8 @@ impl Connectable for PgConnection {
                 .await?;
             let short = version.lines().next().unwrap_or(&version).to_string();
             Ok(Self {
-                config,
+                tunnel,
+                config: stored,
                 pool,
                 server_version: Some(short),
             })
@@ -56,7 +78,7 @@ impl Connectable for PgConnection {
         let config = config.clone();
         Tokio::spawn_result(cx, async move {
             let start = Instant::now();
-            let opts = pg_connect_options(&config);
+            let (opts, _tunnel, _) = connect_opts(&config).await?;
             let pool = PgPoolOptions::new()
                 .max_connections(1)
                 .connect_with(opts)

--- a/apps/desktop/src/postgres/wizard.rs
+++ b/apps/desktop/src/postgres/wizard.rs
@@ -55,6 +55,7 @@ pub(crate) fn parse_postgres_uri(input: &str) -> Option<PostgresConfig> {
         username,
         password,
         ssl_mode,
+        ssh: None,
     })
 }
 

--- a/apps/desktop/src/project/loader.rs
+++ b/apps/desktop/src/project/loader.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use based_core::SshTunnelConfig;
 use based_project::{
-    ConnectionSpec, PragmaSettings, ProjectConnection, load_connections_from_based_dir,
-    load_env_file,
+    ConnectionSpec, PragmaSettings, ProjectConnection, SshSettings,
+    load_connections_from_based_dir, load_env_file,
 };
 use based_sqlite::SqlitePragma;
 
@@ -47,6 +48,11 @@ pub fn entry_from_tree(
             } else {
                 SslMode::Disable
             },
+            ssh: conn
+                .ssh
+                .as_ref()
+                .map(|s| resolve_ssh(s, file_vars))
+                .transpose()?,
         }),
         ConnectionSpec::MongoDB { url, database } => {
             let uri = url.resolve_with(file_vars)?;
@@ -100,6 +106,23 @@ pub fn load_entries_from_based_dir(
         .collect()
 }
 
+fn resolve_ssh(
+    ssh: &SshSettings,
+    file_vars: &HashMap<String, String>,
+) -> anyhow::Result<SshTunnelConfig> {
+    Ok(SshTunnelConfig {
+        host: ssh.host.clone(),
+        port: ssh.port,
+        user: ssh.user.clone(),
+        key_path: ssh.key_path.clone(),
+        key_passphrase: ssh
+            .key_passphrase
+            .as_ref()
+            .map(|v| v.resolve_with(file_vars))
+            .transpose()?,
+    })
+}
+
 fn map_pragma(p: &PragmaSettings) -> SqlitePragma {
     SqlitePragma {
         journal_mode: p.journal_mode.clone().unwrap_or_else(|| "wal".into()),
@@ -128,6 +151,7 @@ mod tests {
                 file: PathBuf::from("/tmp/a.db"),
                 pragma: None,
             },
+            ssh: None,
         };
         write_connection_file(based, &conn).unwrap();
         let entries = load_entries_from_based_dir(based, ConnectionOrigin::Personal);
@@ -154,12 +178,52 @@ mod tests {
                 },
                 ssl: false,
             },
+            ssh: None,
         };
         let mut vars = HashMap::new();
         vars.insert("BASED_PG_PASSWORD".into(), "from-file".into());
         let entry = entry_from_tree(&conn, ConnectionOrigin::Project, &vars).unwrap();
         match entry.config {
             ConnectionConfig::Postgres(c) => assert_eq!(c.password, "from-file"),
+            other => panic!("expected postgres, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn entry_from_tree_resolves_ssh_passphrase() {
+        let conn = ProjectConnection {
+            id: "pg".into(),
+            label: "PG".into(),
+            engine: "postgres".into(),
+            tags: vec![],
+            read_only: false,
+            spec: ConnectionSpec::Postgres {
+                host: "mydb.internal".into(),
+                port: 5432,
+                database: "db".into(),
+                username: "u".into(),
+                password: EnvOrString::Literal(String::new()),
+                ssl: true,
+            },
+            ssh: Some(SshSettings {
+                host: "bastion.example.com".into(),
+                port: 22,
+                user: "ec2-user".into(),
+                key_path: Some("~/.ssh/id_ed25519".into()),
+                key_passphrase: Some(EnvOrString::FromEnv {
+                    var: "BASED_PG_SSH_KEY_PASSPHRASE".into(),
+                }),
+            }),
+        };
+        let mut vars = HashMap::new();
+        vars.insert("BASED_PG_SSH_KEY_PASSPHRASE".into(), "from-file".into());
+        let entry = entry_from_tree(&conn, ConnectionOrigin::Project, &vars).unwrap();
+        match entry.config {
+            ConnectionConfig::Postgres(c) => {
+                let ssh = c.ssh.expect("ssh");
+                assert_eq!(ssh.host, "bastion.example.com");
+                assert_eq!(ssh.key_passphrase.as_deref(), Some("from-file"));
+            }
             other => panic!("expected postgres, got {other:?}"),
         }
     }

--- a/apps/desktop/src/workspace/connection_persist.rs
+++ b/apps/desktop/src/workspace/connection_persist.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use based_project::{
-    ConnectionSpec, EnvOrString, PragmaSettings, ProjectConnection, secret_env_key,
+    ConnectionSpec, EnvOrString, PragmaSettings, ProjectConnection, SshSettings, secret_env_key,
     slug_from_label, upsert_env_file, write_connection_file,
 };
 
@@ -34,12 +34,26 @@ fn persist_secret(
 ) -> anyhow::Result<()> {
     let env_path = based_dir.join(".env");
     match config {
-        ConnectionConfig::Postgres(c) if !c.password.is_empty() => {
-            upsert_env_file(
-                &env_path,
-                &secret_env_key(relative_id, "PASSWORD"),
-                &c.password,
-            )?;
+        ConnectionConfig::Postgres(c) => {
+            if !c.password.is_empty() {
+                upsert_env_file(
+                    &env_path,
+                    &secret_env_key(relative_id, "PASSWORD"),
+                    &c.password,
+                )?;
+            }
+            if let Some(pass) = c
+                .ssh
+                .as_ref()
+                .and_then(|s| s.key_passphrase.as_deref())
+                .filter(|p| !p.is_empty())
+            {
+                upsert_env_file(
+                    &env_path,
+                    &secret_env_key(relative_id, "SSH_KEY_PASSPHRASE"),
+                    pass,
+                )?;
+            }
         }
         ConnectionConfig::MongoDB(c) if !c.uri.is_empty() => {
             upsert_env_file(&env_path, &secret_env_key(relative_id, "URL"), &c.uri)?;
@@ -64,6 +78,21 @@ fn project_connection_from_config(
                     var: secret_env_key(&relative_id, "PASSWORD"),
                 }
             };
+            let ssh =
+                c.ssh
+                    .as_ref()
+                    .filter(|s| s.is_configured())
+                    .map(|s| SshSettings {
+                        host: s.host.clone(),
+                        port: s.port,
+                        user: s.user.clone(),
+                        key_path: s.key_path.clone(),
+                        key_passphrase: s.key_passphrase.as_ref().filter(|p| !p.is_empty()).map(
+                            |_| EnvOrString::FromEnv {
+                                var: secret_env_key(&relative_id, "SSH_KEY_PASSPHRASE"),
+                            },
+                        ),
+                    });
             ProjectConnection {
                 id: relative_id,
                 label: c.label.clone(),
@@ -78,6 +107,7 @@ fn project_connection_from_config(
                     password,
                     ssl: !matches!(c.ssl_mode, SslMode::Disable),
                 },
+                ssh,
             }
         }
         ConnectionConfig::MongoDB(c) => {
@@ -98,6 +128,7 @@ fn project_connection_from_config(
                     url,
                     database: c.database.clone(),
                 },
+                ssh: None,
             }
         }
         ConnectionConfig::SQLite(c) => ProjectConnection {
@@ -110,6 +141,7 @@ fn project_connection_from_config(
                 file: c.path.clone(),
                 pragma: c.pragma.as_ref().map(pragma_from_sqlite),
             },
+            ssh: None,
         },
     }
 }
@@ -144,6 +176,7 @@ mod tests {
             username: "alice".into(),
             password: "s3cret".into(),
             ssl_mode: SslMode::Require,
+            ssh: None,
         });
         let conn = persist_config_to_based_dir(based, &config, &[], None).unwrap();
         assert_eq!(conn.id, "analytics");
@@ -187,6 +220,7 @@ mod tests {
             username: "alice".into(),
             password: String::new(),
             ssl_mode: SslMode::Disable,
+            ssh: None,
         });
         persist_config_to_based_dir(based, &config, &["local".into(), "dev".into()], None).unwrap();
         let loaded = load_connections_from_based_dir(based).unwrap();
@@ -208,6 +242,7 @@ mod tests {
             username: "alice".into(),
             password: String::new(),
             ssl_mode: SslMode::Disable,
+            ssh: None,
         });
         persist_config_to_based_dir(based, &original, &[], None).unwrap();
         let renamed = ConnectionConfig::Postgres(PostgresConfig {
@@ -218,6 +253,7 @@ mod tests {
             username: "alice".into(),
             password: String::new(),
             ssl_mode: SslMode::Disable,
+            ssh: None,
         });
         let conn = persist_config_to_based_dir(based, &renamed, &[], Some("analytics")).unwrap();
         assert_eq!(conn.id, "analytics");
@@ -227,5 +263,39 @@ mod tests {
         let loaded = load_connections_from_based_dir(based).unwrap();
         assert_eq!(loaded[0].id, "analytics");
         assert_eq!(loaded[0].label, "Reporting");
+    }
+
+    #[test]
+    fn persist_postgres_writes_ssh_and_key_passphrase_env() {
+        use based_core::SshTunnelConfig;
+        let dir = tempfile::tempdir().unwrap();
+        let based = dir.path();
+        let config = ConnectionConfig::Postgres(PostgresConfig {
+            label: "Prod".into(),
+            host: "mydb.internal".into(),
+            port: 5432,
+            database: "app".into(),
+            username: "app".into(),
+            password: "dbpass".into(),
+            ssl_mode: SslMode::Require,
+            ssh: Some(SshTunnelConfig {
+                host: "bastion.example.com".into(),
+                port: 22,
+                user: "ec2-user".into(),
+                key_path: Some("~/.ssh/id_ed25519".into()),
+                key_passphrase: Some("keypass".into()),
+            }),
+        });
+        persist_config_to_based_dir(based, &config, &[], None).unwrap();
+        let raw = fs::read_to_string(based.join("connections/prod.toml")).unwrap();
+        assert!(raw.contains("[ssh]"));
+        assert!(raw.contains("bastion.example.com"));
+        assert!(raw.contains("BASED_PROD_SSH_KEY_PASSPHRASE"));
+        assert!(!raw.contains("keypass"));
+        let env = load_env_file(&based.join(".env")).unwrap();
+        assert_eq!(
+            env.get("BASED_PROD_SSH_KEY_PASSPHRASE").map(String::as_str),
+            Some("keypass")
+        );
     }
 }

--- a/apps/desktop/src/workspace/panels/connection_wizard.rs
+++ b/apps/desktop/src/workspace/panels/connection_wizard.rs
@@ -23,6 +23,8 @@ use gpui_component::{
 use tokio::task::spawn_blocking;
 use uuid::Uuid;
 
+use based_core::SshTunnelConfig;
+
 use crate::app::prefs;
 use crate::connection::{
     ConnectionConfig, ConnectionEntry, ConnectionId, EngineKind, OpenedConnection,
@@ -73,6 +75,12 @@ pub struct ConnectionWizardPanel {
     password: Entity<InputState>,
     ssl_enabled: bool,
     ssl_mode: Entity<SelectState<Vec<&'static str>>>,
+    ssh_enabled: bool,
+    ssh_host: Entity<InputState>,
+    ssh_port: Entity<InputState>,
+    ssh_user: Entity<InputState>,
+    ssh_key_path: Entity<InputState>,
+    ssh_key_passphrase: Entity<InputState>,
     uri: Entity<InputState>,
     mongo_uri: Entity<InputState>,
     mongo_database: Entity<InputState>,
@@ -140,6 +148,16 @@ impl ConnectionWizardPanel {
             ssl_enabled: false,
             ssl_mode: cx.new(|cx| {
                 SelectState::new(SSL_ON_LABELS.to_vec(), Some(IndexPath::new(0)), window, cx)
+            }),
+            ssh_enabled: false,
+            ssh_host: new_field(window, cx, "", "bastion.example.com"),
+            ssh_port: new_field(window, cx, "22", "22"),
+            ssh_user: new_field(window, cx, "", "ec2-user"),
+            ssh_key_path: new_field(window, cx, "", "~/.ssh/id_ed25519"),
+            ssh_key_passphrase: cx.new(|cx| {
+                InputState::new(window, cx)
+                    .placeholder("Key passphrase (optional)")
+                    .masked(true)
             }),
             uri,
             mongo_uri: new_field(
@@ -215,6 +233,7 @@ impl ConnectionWizardPanel {
                         select.set_selected_value(&label, window, cx);
                     });
                 }
+                self.apply_ssh(c.ssh.as_ref(), window, cx);
             }
             ConnectionConfig::MongoDB(c) => {
                 set_field(&self.mongo_uri, &c.uri, window, cx);
@@ -241,6 +260,52 @@ impl ConnectionWizardPanel {
         }
     }
 
+    fn apply_ssh(
+        &mut self,
+        ssh: Option<&SshTunnelConfig>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match ssh {
+            Some(ssh) => {
+                self.ssh_enabled = true;
+                set_field(&self.ssh_host, &ssh.host, window, cx);
+                set_field(&self.ssh_port, &ssh.port.to_string(), window, cx);
+                set_field(&self.ssh_user, &ssh.user, window, cx);
+                set_field(
+                    &self.ssh_key_path,
+                    ssh.key_path.as_deref().unwrap_or(""),
+                    window,
+                    cx,
+                );
+                set_field(
+                    &self.ssh_key_passphrase,
+                    ssh.key_passphrase.as_deref().unwrap_or(""),
+                    window,
+                    cx,
+                );
+            }
+            None => {
+                self.ssh_enabled = false;
+            }
+        }
+    }
+
+    fn current_ssh(&self, cx: &App) -> Option<SshTunnelConfig> {
+        if !self.ssh_enabled {
+            return None;
+        }
+        let key_path = self.ssh_key_path.read(cx).value().to_string();
+        let key_passphrase = self.ssh_key_passphrase.read(cx).value().to_string();
+        Some(SshTunnelConfig {
+            host: self.ssh_host.read(cx).value().to_string(),
+            port: self.ssh_port.read(cx).value().parse().unwrap_or(22),
+            user: self.ssh_user.read(cx).value().to_string(),
+            key_path: nonempty_opt(&key_path),
+            key_passphrase: nonempty_opt(&key_passphrase),
+        })
+    }
+
     fn current_ssl_mode(&self, cx: &App) -> SslMode {
         let selected = self
             .ssl_mode
@@ -261,6 +326,7 @@ impl ConnectionWizardPanel {
                 username: self.username.read(cx).value().to_string(),
                 password: self.password.read(cx).value().to_string(),
                 ssl_mode: self.current_ssl_mode(cx),
+                ssh: self.current_ssh(cx),
             }),
             EngineKind::MongoDB => {
                 let database = self.mongo_database.read(cx).value().to_string();
@@ -533,6 +599,37 @@ impl ConnectionWizardPanel {
         .detach();
     }
 
+    fn browse_ssh_key(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let path_field = self.ssh_key_path.clone();
+        cx.spawn_in(window, async move |this, cx| {
+            let picked = db::run_infallible(cx, async {
+                spawn_blocking(|| {
+                    rfd::FileDialog::new()
+                        .set_title("Choose SSH private key")
+                        .pick_file()
+                })
+                .await
+                .ok()
+                .flatten()
+            })
+            .await
+            .ok()
+            .flatten();
+
+            let Some(path) = picked else {
+                return;
+            };
+            let _ = cx.update(|window, cx| {
+                this.update(cx, |panel, cx| {
+                    set_field(&path_field, &path.display().to_string(), window, cx);
+                    panel.status = WizardStatus::Idle;
+                    cx.notify();
+                })
+            });
+        })
+        .detach();
+    }
+
     fn busy(&self) -> bool {
         matches!(
             self.status,
@@ -775,6 +872,90 @@ impl Render for ConnectionWizardPanel {
                                 "SSL mode",
                                 muted,
                                 Select::new(&self.ssl_mode).w_full(),
+                            ))
+                        })
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .items_center()
+                                .justify_between()
+                                .child(div().text_sm().child("SSH tunnel"))
+                                .child(
+                                    Switch::new("wizard-ssh")
+                                        .with_size(Size::Small)
+                                        .checked(self.ssh_enabled)
+                                        .on_click(cx.listener(|panel, checked, _, cx| {
+                                            panel.ssh_enabled = *checked;
+                                            cx.notify();
+                                        })),
+                                ),
+                        )
+                        .when(self.ssh_enabled, |v| {
+                            v.child(
+                                h_flex()
+                                    .gap_2()
+                                    .child(labeled_field(
+                                        "SSH host",
+                                        muted,
+                                        Input::new(&self.ssh_host)
+                                            .cleanable(true)
+                                            .aria_label("SSH host"),
+                                    ))
+                                    .child(labeled_fixed(
+                                        "SSH port",
+                                        muted,
+                                        96.0,
+                                        Input::new(&self.ssh_port)
+                                            .cleanable(true)
+                                            .aria_label("SSH port"),
+                                    )),
+                            )
+                            .child(labeled_field(
+                                "SSH user",
+                                muted,
+                                Input::new(&self.ssh_user)
+                                    .content_type(InputContentType::Username)
+                                    .cleanable(true)
+                                    .aria_label("SSH user"),
+                            ))
+                            .child(
+                                v_flex()
+                                    .gap_1()
+                                    .child(div().text_xs().text_color(muted).child("Key path"))
+                                    .child(
+                                        h_flex()
+                                            .gap_2()
+                                            .items_center()
+                                            .child(
+                                                Input::new(&self.ssh_key_path)
+                                                    .cleanable(true)
+                                                    .aria_label("SSH key path")
+                                                    .flex_1(),
+                                            )
+                                            .child(
+                                                Button::new("wizard-ssh-browse")
+                                                    .label("Browse…")
+                                                    .on_click(cx.listener(
+                                                        |panel, _, window, cx| {
+                                                            panel.browse_ssh_key(window, cx);
+                                                        },
+                                                    )),
+                                            ),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .text_color(muted)
+                                            .child("Leave empty to use ssh-agent."),
+                                    ),
+                            )
+                            .child(labeled_field(
+                                "Key passphrase",
+                                muted,
+                                Input::new(&self.ssh_key_passphrase)
+                                    .content_type(InputContentType::Password)
+                                    .mask_toggle()
+                                    .aria_label("SSH key passphrase"),
                             ))
                         })
                     })

--- a/apps/desktop/src/workspace/templates.rs
+++ b/apps/desktop/src/workspace/templates.rs
@@ -116,6 +116,7 @@ pub fn resolve_template_entry(
                 username: resolved.username,
                 password: resolved.password,
                 ssl_mode,
+                ssh: None,
             })
         }
         EngineKind::MongoDB => ConnectionConfig::MongoDB(MongoConfig {
@@ -198,6 +199,7 @@ mod tests {
             username: "alice".into(),
             password: "s3cret".into(),
             ssl_mode: SslMode::Require,
+            ssh: None,
         });
         let template = template_from_config(&config, None);
         assert_eq!(template.engine, EngineKind::Postgres);
@@ -252,6 +254,7 @@ mod tests {
             username: "postgres".into(),
             password: String::new(),
             ssl_mode: SslMode::Prefer,
+            ssh: None,
         });
         let existing = template_from_config(&config, None);
         ws.connection_templates.push(existing.clone());

--- a/apps/desktop/src/workspace/wizard_logic.rs
+++ b/apps/desktop/src/workspace/wizard_logic.rs
@@ -134,6 +134,7 @@ pub fn open_params_changed(old: &ConnectionConfig, new: &ConnectionConfig) -> bo
                 || a.username != b.username
                 || a.password != b.password
                 || ssl_mode_key(a.ssl_mode) != ssl_mode_key(b.ssl_mode)
+                || a.ssh != b.ssh
         }
         (ConnectionConfig::MongoDB(a), ConnectionConfig::MongoDB(b)) => {
             a.uri != b.uri || a.database != b.database || a.auth_source != b.auth_source
@@ -356,6 +357,7 @@ mod tests {
             username: "postgres".into(),
             password: String::new(),
             ssl_mode: SslMode::Disable,
+            ssh: None,
         })
         .with_label("Analytics".into());
         assert_eq!(config.label(), "Analytics");
@@ -390,6 +392,7 @@ mod tests {
             username: "postgres".into(),
             password: "s3cret".into(),
             ssl_mode: SslMode::Disable,
+            ssh: None,
         })
     }
 
@@ -428,5 +431,21 @@ mod tests {
         assert!(open_params_changed(&old, &new));
         assert!(should_reconnect_after_save(true, &old, &new));
         assert!(!should_reconnect_after_save(false, &old, &new));
+    }
+
+    #[test]
+    fn open_params_detect_ssh_change() {
+        let old = pg("Prod", "mydb.internal");
+        let mut new = pg("Prod", "mydb.internal");
+        if let ConnectionConfig::Postgres(c) = &mut new {
+            c.ssh = Some(based_core::SshTunnelConfig {
+                host: "bastion.example.com".into(),
+                port: 22,
+                user: "ec2-user".into(),
+                key_path: None,
+                key_passphrase: None,
+            });
+        }
+        assert!(open_params_changed(&old, &new));
     }
 }

--- a/apps/web/src/pages/docs/connections.astro
+++ b/apps/web/src/pages/docs/connections.astro
@@ -37,6 +37,26 @@ tags = ["staging"]
 url = { env = "MONGO_URL" }
 database = "analytics"
 `;
+
+const sshToml = `schema_version = 1
+label = "Prod Postgres"
+engine = "postgres"
+
+host = "mydb.internal"
+port = 5432
+database = "app"
+username = "app"
+password = { env = "BASED_PROD_PASSWORD" }
+ssl = true
+
+[ssh]
+host = "bastion.example.com"
+port = 22
+user = "ec2-user"
+# omit key_path to use ssh-agent
+key_path = "~/.ssh/id_ed25519"
+key_passphrase = { env = "BASED_PROD_SSH_KEY_PASSPHRASE" }
+`;
 ---
 
 <DocsLayout
@@ -147,6 +167,14 @@ database = "analytics"
     Verify CA / Verify Full, use the in-app wizard (session connection) until
     those modes exist on the file format.
   </p>
+  <p>
+    Optional <code>[ssh]</code> adds one hop: Based SSHs to the bastion, then
+    local-forwards to <code>host</code>:<code>port</code> as seen from that
+    machine. Host keys are checked against <code>~/.ssh/known_hosts</code>.
+    Leave <code>key_path</code> out to use the SSH agent. Verify CA / Verify
+    Full are not supported through the tunnel yet — use Require.
+  </p>
+  <CodeSample filename=".based/connections/prod.toml" code={sshToml} />
 
   <h3>SQLite</h3>
   <CodeSample filename=".based/connections/local/northwind.toml" code={sqliteToml} />

--- a/crates/based-core/src/connection_error.rs
+++ b/crates/based-core/src/connection_error.rs
@@ -87,7 +87,9 @@ impl fmt::Display for ConnectionErrorDetail {
 /// Best-effort mapping from driver error strings (sqlx, etc.).
 pub fn categorize_connect_error(err: &str) -> ConnectionErrorDetail {
     let lower = err.to_ascii_lowercase();
-    let category = if lower.contains("password authentication failed")
+    let category = if lower.contains("ssh tunnel") || lower.contains("known_hosts") {
+        ConnectionErrorCategory::SshFailed
+    } else if lower.contains("password authentication failed")
         || lower.contains("authentication failed")
         || lower.contains("invalid password")
     {
@@ -123,5 +125,17 @@ mod tests {
     fn maps_auth_failure() {
         let d = categorize_connect_error("password authentication failed for user \"x\"");
         assert_eq!(d.category, ConnectionErrorCategory::AuthFailed);
+    }
+
+    #[test]
+    fn maps_ssh_tunnel_before_generic_auth() {
+        let d = categorize_connect_error("SSH tunnel: authentication failed");
+        assert_eq!(d.category, ConnectionErrorCategory::SshFailed);
+    }
+
+    #[test]
+    fn maps_unknown_host_key() {
+        let d = categorize_connect_error("SSH tunnel: host is not in known_hosts");
+        assert_eq!(d.category, ConnectionErrorCategory::SshFailed);
     }
 }

--- a/crates/based-core/src/lib.rs
+++ b/crates/based-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod connection_error;
 pub mod connection_id;
 pub mod engine;
 pub mod session;
+pub mod ssh;
 pub mod tab;
 
 pub use auth::AuthMethod;
@@ -14,4 +15,5 @@ pub use connection_error::{
 pub use connection_id::ConnectionId;
 pub use engine::EngineKind;
 pub use session::{PersistedConnection, WorkspaceState};
+pub use ssh::SshTunnelConfig;
 pub use tab::{TabId, TabKind};

--- a/crates/based-core/src/ssh.rs
+++ b/crates/based-core/src/ssh.rs
@@ -1,0 +1,52 @@
+//! Runtime SSH tunnel settings (resolved secrets, no project-file types).
+
+use serde::{Deserialize, Serialize};
+
+fn default_ssh_port() -> u16 {
+    22
+}
+
+/// One SSH hop used as a local-forward transport to a database.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SshTunnelConfig {
+    pub host: String,
+    #[serde(default = "default_ssh_port")]
+    pub port: u16,
+    pub user: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_passphrase: Option<String>,
+}
+
+impl SshTunnelConfig {
+    pub fn is_configured(&self) -> bool {
+        !self.host.trim().is_empty() && !self.user.trim().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_port_is_22() {
+        let m: SshTunnelConfig =
+            serde_json::from_str(r#"{"host":"bastion.example.com","user":"ec2-user"}"#).unwrap();
+        assert_eq!(m.port, 22);
+        assert!(m.key_path.is_none());
+        assert!(m.is_configured());
+    }
+
+    #[test]
+    fn empty_host_or_user_is_not_configured() {
+        let m = SshTunnelConfig {
+            host: "  ".into(),
+            port: 22,
+            user: "ec2-user".into(),
+            key_path: None,
+            key_passphrase: None,
+        };
+        assert!(!m.is_configured());
+    }
+}

--- a/crates/based-postgres/Cargo.toml
+++ b/crates/based-postgres/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+based-core = { path = "../based-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["postgres"] }

--- a/crates/based-postgres/src/config.rs
+++ b/crates/based-postgres/src/config.rs
@@ -1,3 +1,4 @@
+use based_core::SshTunnelConfig;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
 
@@ -10,6 +11,8 @@ pub struct PostgresConfig {
     pub username: String,
     pub password: String,
     pub ssl_mode: SslMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh: Option<SshTunnelConfig>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
@@ -109,6 +112,7 @@ mod tests {
             username: "alice".into(),
             password: "s3cret".into(),
             ssl_mode: SslMode::Require,
+            ssh: None,
         }
     }
 
@@ -149,6 +153,7 @@ mod tests {
             username: "al ice".into(),
             password: "p@ss:w/rd".into(),
             ssl_mode: SslMode::Prefer,
+            ssh: None,
         };
         assert_eq!(
             postgres_uri(&cfg, true),

--- a/crates/based-project/src/connection.rs
+++ b/crates/based-project/src/connection.rs
@@ -17,6 +17,17 @@ pub struct ProjectConnection {
     pub tags: Vec<String>,
     pub read_only: bool,
     pub spec: ConnectionSpec,
+    pub ssh: Option<SshSettings>,
+}
+
+/// Optional SSH hop persisted as `[ssh]` on a connection file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshSettings {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub key_path: Option<String>,
+    pub key_passphrase: Option<EnvOrString>,
 }
 
 #[derive(Debug, Clone)]
@@ -76,6 +87,22 @@ struct RawConnectionFile {
     pragma: Option<PragmaSettings>,
     #[serde(default)]
     read_only: Option<bool>,
+    #[serde(default)]
+    ssh: Option<RawSsh>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RawSsh {
+    #[serde(default)]
+    host: Option<String>,
+    #[serde(default)]
+    port: Option<u16>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_passphrase: Option<EnvOrString>,
 }
 
 pub fn load_connections(project_root: &Path) -> Result<Vec<ProjectConnection>> {
@@ -158,6 +185,8 @@ struct WriteConnectionFile {
     url: Option<EnvOrString>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pragma: Option<PragmaSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ssh: Option<RawSsh>,
 }
 
 impl From<&ProjectConnection> for WriteConnectionFile {
@@ -177,6 +206,13 @@ impl From<&ProjectConnection> for WriteConnectionFile {
             ssl: None,
             url: None,
             pragma: None,
+            ssh: conn.ssh.as_ref().map(|s| RawSsh {
+                host: Some(s.host.clone()),
+                port: Some(s.port),
+                user: Some(s.user.clone()),
+                key_path: s.key_path.clone(),
+                key_passphrase: s.key_passphrase.clone(),
+            }),
         };
         match &conn.spec {
             ConnectionSpec::Sqlite { file, pragma } => {
@@ -271,6 +307,7 @@ fn parse_connection_file(connections_dir: &Path, path: &Path) -> Result<ProjectC
         other => bail!("unknown engine {other:?} in {}", path.display()),
     };
     let read_only = resolve_read_only(file.read_only, &file.tags);
+    let ssh = parse_ssh(file.ssh, &id)?;
     Ok(ProjectConnection {
         id,
         label: file.label,
@@ -278,7 +315,26 @@ fn parse_connection_file(connections_dir: &Path, path: &Path) -> Result<ProjectC
         tags: file.tags,
         read_only,
         spec,
+        ssh,
     })
+}
+
+fn parse_ssh(raw: Option<RawSsh>, connection_id: &str) -> Result<Option<SshSettings>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let host = raw.host.unwrap_or_default();
+    let user = raw.user.unwrap_or_default();
+    if host.trim().is_empty() || user.trim().is_empty() {
+        bail!("connection {connection_id} [ssh] requires `host` and `user`");
+    }
+    Ok(Some(SshSettings {
+        host,
+        port: raw.port.unwrap_or(22),
+        user,
+        key_path: raw.key_path.filter(|p| !p.trim().is_empty()),
+        key_passphrase: raw.key_passphrase,
+    }))
 }
 
 fn resolve_read_only(explicit: Option<bool>, tags: &[String]) -> bool {
@@ -382,6 +438,116 @@ ssl = false
     }
 
     #[test]
+    fn parse_postgres_ssh_table_defaults_port_22() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn_dir = dir.path().join("connections");
+        fs::create_dir_all(&conn_dir).unwrap();
+        let path = conn_dir.join("prod.toml");
+        fs::write(
+            &path,
+            r#"
+schema_version = 1
+label = "Prod"
+engine = "postgres"
+host = "mydb.internal"
+port = 5432
+database = "app"
+username = "app"
+password = ""
+ssl = true
+
+[ssh]
+host = "bastion.example.com"
+user = "ec2-user"
+key_path = "~/.ssh/id_ed25519"
+"#,
+        )
+        .unwrap();
+        let conn = parse_connection_file(&conn_dir, &path).unwrap();
+        let ssh = conn.ssh.expect("ssh table");
+        assert_eq!(ssh.host, "bastion.example.com");
+        assert_eq!(ssh.port, 22);
+        assert_eq!(ssh.user, "ec2-user");
+        assert_eq!(ssh.key_path.as_deref(), Some("~/.ssh/id_ed25519"));
+        assert!(ssh.key_passphrase.is_none());
+    }
+
+    #[test]
+    fn empty_ssh_table_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn_dir = dir.path().join("connections");
+        fs::create_dir_all(&conn_dir).unwrap();
+        let path = conn_dir.join("bad.toml");
+        fs::write(
+            &path,
+            r#"
+schema_version = 1
+label = "Prod"
+engine = "postgres"
+host = "mydb.internal"
+port = 5432
+database = "app"
+username = "app"
+password = ""
+ssl = false
+
+[ssh]
+"#,
+        )
+        .unwrap();
+        let err = parse_connection_file(&conn_dir, &path).unwrap_err();
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("ssh"),
+            "expected ssh validation error, got {err}"
+        );
+    }
+
+    #[test]
+    fn write_then_load_ssh_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let based = dir.path();
+        let conn = ProjectConnection {
+            id: "prod".into(),
+            label: "Prod".into(),
+            engine: "postgres".into(),
+            tags: vec![],
+            read_only: false,
+            spec: ConnectionSpec::Postgres {
+                host: "mydb.internal".into(),
+                port: 5432,
+                database: "app".into(),
+                username: "app".into(),
+                password: EnvOrString::Literal(String::new()),
+                ssl: true,
+            },
+            ssh: Some(SshSettings {
+                host: "bastion.example.com".into(),
+                port: 22,
+                user: "ec2-user".into(),
+                key_path: Some("~/.ssh/id_ed25519".into()),
+                key_passphrase: Some(EnvOrString::FromEnv {
+                    var: "BASED_PROD_SSH_KEY_PASSPHRASE".into(),
+                }),
+            }),
+        };
+        write_connection_file(based, &conn).unwrap();
+        let raw = fs::read_to_string(based.join("connections/prod.toml")).unwrap();
+        assert!(raw.contains("[ssh]"));
+        assert!(raw.contains("bastion.example.com"));
+        assert!(raw.contains("BASED_PROD_SSH_KEY_PASSPHRASE"));
+        assert!(!raw.contains("s3cret"));
+        let loaded = load_connections_from_based_dir(based).unwrap();
+        let ssh = loaded[0].ssh.as_ref().expect("ssh");
+        assert_eq!(ssh.user, "ec2-user");
+        assert_eq!(
+            ssh.key_passphrase,
+            Some(EnvOrString::FromEnv {
+                var: "BASED_PROD_SSH_KEY_PASSPHRASE".into(),
+            })
+        );
+    }
+
+    #[test]
     fn write_then_load_postgres_and_sqlite_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let based = dir.path();
@@ -401,6 +567,7 @@ ssl = false
                 },
                 ssl: true,
             },
+            ssh: None,
         };
         let sqlite = ProjectConnection {
             id: "northwind".into(),
@@ -412,6 +579,7 @@ ssl = false
                 file: PathBuf::from("/tmp/northwind.db"),
                 pragma: None,
             },
+            ssh: None,
         };
         let pg_path = write_connection_file(based, &postgres).unwrap();
         let sqlite_path = write_connection_file(based, &sqlite).unwrap();

--- a/crates/based-project/src/lib.rs
+++ b/crates/based-project/src/lib.rs
@@ -12,7 +12,7 @@ mod target;
 mod walk;
 
 pub use connection::{
-    ConnectionSpec, PragmaSettings, ProjectConnection, load_connections,
+    ConnectionSpec, PragmaSettings, ProjectConnection, SshSettings, load_connections,
     load_connections_from_based_dir, slug_from_label, write_connection_file,
 };
 pub use dotenv::{load_env_file, secret_env_key, upsert_env_file};

--- a/crates/based-ssh/Cargo.toml
+++ b/crates/based-ssh/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "based-ssh"
+version = "0.0.0-dev"
+edition = "2024"
+description = "SSH local-forward tunnel for Based connections"
+license = "MIT"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+based-core = { path = "../based-core" }
+dirs = { workspace = true }
+log = { workspace = true }
+russh = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+
+[dev-dependencies]
+rand_core = { version = "0.6", features = ["getrandom"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util"] }
+
+[lints]
+workspace = true

--- a/crates/based-ssh/src/lib.rs
+++ b/crates/based-ssh/src/lib.rs
@@ -1,0 +1,7 @@
+//! SSH local-forward used as a transport hop in front of a database engine.
+
+mod path;
+mod tunnel;
+
+pub use path::{expand_key_path, expand_tilde};
+pub use tunnel::{SshTunnel, open_tunnel, open_tunnel_with_known_hosts};

--- a/crates/based-ssh/src/path.rs
+++ b/crates/based-ssh/src/path.rs
@@ -1,0 +1,40 @@
+//! Expand `~` in SSH identity paths.
+
+use std::path::PathBuf;
+
+pub fn expand_tilde(path: &str) -> PathBuf {
+    let path = path.trim();
+    if path == "~" {
+        return dirs::home_dir().unwrap_or_else(|| PathBuf::from("~"));
+    }
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    PathBuf::from(path)
+}
+
+pub fn expand_key_path(path: &str) -> PathBuf {
+    expand_tilde(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_tilde_joins_home() {
+        let home = dirs::home_dir().expect("home dir");
+        assert_eq!(expand_tilde("~/id_ed25519"), home.join("id_ed25519"));
+        assert_eq!(expand_tilde("~"), home);
+    }
+
+    #[test]
+    fn expand_tilde_leaves_absolute_paths() {
+        assert_eq!(
+            expand_tilde("/abs/id_ed25519"),
+            PathBuf::from("/abs/id_ed25519")
+        );
+    }
+}

--- a/crates/based-ssh/src/tunnel.rs
+++ b/crates/based-ssh/src/tunnel.rs
@@ -1,0 +1,228 @@
+//! Local-forward an SSH hop to a remote TCP endpoint.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use based_core::SshTunnelConfig;
+use russh::keys::{HashAlg, PrivateKeyWithHashAlg, PublicKey, load_secret_key};
+use russh::{
+    Channel, client,
+    keys::agent::client::AgentClient,
+    keys::known_hosts::{check_known_hosts, check_known_hosts_path},
+};
+use tokio::io::{AsyncWriteExt, copy_bidirectional};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, oneshot};
+
+use crate::path::expand_key_path;
+
+struct ClientHandler {
+    host: String,
+    port: u16,
+    known_hosts: Option<PathBuf>,
+}
+
+impl client::Handler for ClientHandler {
+    type Error = anyhow::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &PublicKey,
+    ) -> Result<bool, Self::Error> {
+        let verified = match &self.known_hosts {
+            Some(path) => check_known_hosts_path(&self.host, self.port, server_public_key, path),
+            None => check_known_hosts(&self.host, self.port, server_public_key),
+        };
+        match verified {
+            Ok(true) => Ok(true),
+            Ok(false) => bail!(
+                "SSH tunnel: host {} is not in known_hosts. Add it with `ssh {}@{}` once.",
+                self.host,
+                self.host,
+                self.port
+            ),
+            Err(err) => bail!("SSH tunnel: host key verification failed: {err}"),
+        }
+    }
+}
+
+/// Live local-forward. Dropping it closes the listen port and SSH session.
+pub struct SshTunnel {
+    local_addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<Arc<Mutex<client::Handle<ClientHandler>>>>,
+}
+
+impl SshTunnel {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn local_port(&self) -> u16 {
+        self.local_addr.port()
+    }
+}
+
+impl Drop for SshTunnel {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            tokio::spawn(async move {
+                drop(handle);
+            });
+        }
+    }
+}
+
+/// Open a local forward to `remote_host:remote_port` via `ssh`.
+pub async fn open_tunnel(
+    ssh: &SshTunnelConfig,
+    remote_host: &str,
+    remote_port: u16,
+) -> Result<SshTunnel> {
+    open_tunnel_with_known_hosts(ssh, remote_host, remote_port, None).await
+}
+
+pub async fn open_tunnel_with_known_hosts(
+    ssh: &SshTunnelConfig,
+    remote_host: &str,
+    remote_port: u16,
+    known_hosts: Option<PathBuf>,
+) -> Result<SshTunnel> {
+    if !ssh.is_configured() {
+        bail!("SSH tunnel: host and user are required");
+    }
+
+    let handler = ClientHandler {
+        host: ssh.host.clone(),
+        port: ssh.port,
+        known_hosts,
+    };
+    let config = Arc::new(client::Config::default());
+    let mut session = client::connect(config, (ssh.host.as_str(), ssh.port), handler)
+        .await
+        .map_err(|err| anyhow::anyhow!("SSH tunnel: {err}"))?;
+
+    authenticate(&mut session, ssh).await?;
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("SSH tunnel: bind local port")?;
+    let local_addr = listener.local_addr().context("SSH tunnel: local address")?;
+    let remote_host = remote_host.to_string();
+    let session = Arc::new(Mutex::new(session));
+    let handle = session.clone();
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => break,
+                accepted = listener.accept() => {
+                    let Ok((socket, _)) = accepted else { break };
+                    let handle = handle.clone();
+                    let remote_host = remote_host.clone();
+                    tokio::spawn(async move {
+                        if let Err(err) = forward_one(handle, socket, &remote_host, remote_port).await {
+                            log::debug!("SSH tunnel forward ended: {err:#}");
+                        }
+                    });
+                }
+            }
+        }
+    });
+
+    Ok(SshTunnel {
+        local_addr,
+        shutdown: Some(shutdown_tx),
+        handle: Some(session),
+    })
+}
+
+async fn authenticate(
+    session: &mut client::Handle<ClientHandler>,
+    ssh: &SshTunnelConfig,
+) -> Result<()> {
+    if let Some(key_path) = ssh.key_path.as_deref().filter(|p| !p.trim().is_empty()) {
+        let path = expand_key_path(key_path);
+        let key = load_secret_key(&path, ssh.key_passphrase.as_deref())
+            .with_context(|| format!("SSH tunnel: could not load key {}", path.display()))?;
+        let hash = session
+            .best_supported_rsa_hash()
+            .await
+            .ok()
+            .flatten()
+            .flatten();
+        let key = PrivateKeyWithHashAlg::new(Arc::new(key), hash);
+        let result = session
+            .authenticate_publickey(ssh.user.clone(), key)
+            .await
+            .context("SSH tunnel: public-key authentication failed")?;
+        if !result.success() {
+            bail!("SSH tunnel: authentication failed");
+        }
+        return Ok(());
+    }
+
+    authenticate_with_agent(session, &ssh.user).await
+}
+
+async fn authenticate_with_agent(
+    session: &mut client::Handle<ClientHandler>,
+    user: &str,
+) -> Result<()> {
+    let mut agent = AgentClient::connect_env()
+        .await
+        .context("SSH tunnel: could not connect to ssh-agent (SSH_AUTH_SOCK)")?;
+    let identities = agent
+        .request_identities()
+        .await
+        .context("SSH tunnel: ssh-agent has no identities")?;
+    if identities.is_empty() {
+        bail!("SSH tunnel: ssh-agent has no identities");
+    }
+    let hash = session
+        .best_supported_rsa_hash()
+        .await
+        .ok()
+        .flatten()
+        .flatten();
+    let hash = hash.or(Some(HashAlg::Sha256));
+    let mut last_err = None;
+    for public in identities {
+        match session
+            .authenticate_publickey_with(user, public, hash, &mut agent)
+            .await
+        {
+            Ok(result) if result.success() => return Ok(()),
+            Ok(_) => {}
+            Err(err) => last_err = Some(err),
+        }
+    }
+    if let Some(err) = last_err {
+        bail!("SSH tunnel: authentication failed: {err}");
+    }
+    bail!("SSH tunnel: authentication failed");
+}
+
+async fn forward_one(
+    handle: Arc<Mutex<client::Handle<ClientHandler>>>,
+    mut socket: TcpStream,
+    remote_host: &str,
+    remote_port: u16,
+) -> Result<()> {
+    let channel: Channel<client::Msg> = handle
+        .lock()
+        .await
+        .channel_open_direct_tcpip(remote_host, u32::from(remote_port), "127.0.0.1", 0)
+        .await
+        .context("SSH tunnel: could not open direct-tcpip channel")?;
+    let mut ssh_stream = channel.into_stream();
+    let _ = copy_bidirectional(&mut socket, &mut ssh_stream).await;
+    let _ = socket.shutdown().await;
+    Ok(())
+}

--- a/crates/based-ssh/tests/forward.rs
+++ b/crates/based-ssh/tests/forward.rs
@@ -1,0 +1,161 @@
+use std::fs;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use based_core::SshTunnelConfig;
+use based_ssh::open_tunnel_with_known_hosts;
+use rand_core::OsRng;
+use russh::keys::known_hosts::learn_known_hosts_path;
+use russh::keys::ssh_key::LineEnding;
+use russh::keys::{Algorithm, PrivateKey, PublicKey};
+use russh::server::{Auth, Config, Msg, Server as _, Session};
+use russh::{Channel, server};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional};
+use tokio::net::{TcpListener, TcpStream};
+
+#[derive(Clone)]
+struct ForwardServer {
+    client_pubkey: PublicKey,
+}
+
+impl server::Server for ForwardServer {
+    type Handler = Handler;
+    fn new_client(&mut self, _: Option<SocketAddr>) -> Self::Handler {
+        Handler {
+            client_pubkey: self.client_pubkey.clone(),
+        }
+    }
+}
+
+struct Handler {
+    client_pubkey: PublicKey,
+}
+
+impl server::Handler for Handler {
+    type Error = russh::Error;
+
+    async fn auth_publickey(
+        &mut self,
+        _user: &str,
+        public_key: &PublicKey,
+    ) -> Result<Auth, Self::Error> {
+        if public_key == &self.client_pubkey {
+            Ok(Auth::Accept)
+        } else {
+            Ok(Auth::reject())
+        }
+    }
+
+    async fn channel_open_direct_tcpip(
+        &mut self,
+        channel: Channel<Msg>,
+        host_to_connect: &str,
+        port_to_connect: u32,
+        _originator_address: &str,
+        _originator_port: u32,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        let mut dest = TcpStream::connect((host_to_connect, port_to_connect as u16))
+            .await
+            .map_err(|_| russh::Error::Disconnect)?;
+        tokio::spawn(async move {
+            let mut stream = channel.into_stream();
+            let _ = copy_bidirectional(&mut dest, &mut stream).await;
+        });
+        Ok(true)
+    }
+}
+
+async fn start_echo() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 64];
+        let n = socket.read(&mut buf).await.unwrap();
+        socket.write_all(&buf[..n]).await.unwrap();
+    });
+    port
+}
+
+async fn start_ssh(server_key: PrivateKey, client_pubkey: PublicKey) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let config = Config {
+        auth_rejection_time: Duration::from_millis(1),
+        auth_rejection_time_initial: Some(Duration::ZERO),
+        keys: vec![server_key],
+        ..Default::default()
+    };
+    let mut server = ForwardServer { client_pubkey };
+    tokio::spawn(async move {
+        let _ = server.run_on_socket(Arc::new(config), &listener).await;
+    });
+    port
+}
+
+#[tokio::test]
+async fn unknown_host_key_is_rejected() {
+    let client_key = PrivateKey::random(&mut OsRng, Algorithm::Ed25519).unwrap();
+    let server_key = PrivateKey::random(&mut OsRng, Algorithm::Ed25519).unwrap();
+    let ssh_port = start_ssh(server_key, client_key.public_key().clone()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("id_ed25519");
+    client_key
+        .write_openssh_file(&key_path, LineEnding::LF)
+        .unwrap();
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, "").unwrap();
+
+    let ssh = SshTunnelConfig {
+        host: "127.0.0.1".into(),
+        port: ssh_port,
+        user: "test".into(),
+        key_path: Some(key_path.display().to_string()),
+        key_passphrase: None,
+    };
+    let err = match open_tunnel_with_known_hosts(&ssh, "127.0.0.1", 1, Some(known_hosts)).await {
+        Ok(_) => panic!("expected unknown host key to fail"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("known_hosts") || msg.contains("SSH tunnel"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn forwards_bytes_through_local_port() {
+    let echo_port = start_echo().await;
+    let client_key = PrivateKey::random(&mut OsRng, Algorithm::Ed25519).unwrap();
+    let server_key = PrivateKey::random(&mut OsRng, Algorithm::Ed25519).unwrap();
+    let server_pub = server_key.public_key().clone();
+    let ssh_port = start_ssh(server_key, client_key.public_key().clone()).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("id_ed25519");
+    client_key
+        .write_openssh_file(&key_path, LineEnding::LF)
+        .unwrap();
+    let known_hosts = dir.path().join("known_hosts");
+    learn_known_hosts_path("127.0.0.1", ssh_port, &server_pub, &known_hosts).unwrap();
+
+    let ssh = SshTunnelConfig {
+        host: "127.0.0.1".into(),
+        port: ssh_port,
+        user: "test".into(),
+        key_path: Some(key_path.display().to_string()),
+        key_passphrase: None,
+    };
+    let tunnel = open_tunnel_with_known_hosts(&ssh, "127.0.0.1", echo_port, Some(known_hosts))
+        .await
+        .expect("open tunnel");
+
+    let mut client = TcpStream::connect(tunnel.local_addr()).await.unwrap();
+    client.write_all(b"ping").await.unwrap();
+    let mut buf = [0u8; 4];
+    client.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"ping");
+}


### PR DESCRIPTION
## Summary
- Add a one-hop SSH tunnel (bastion) so Postgres can reach private hosts via russh, with key file or ssh-agent and strict `~/.ssh/known_hosts`.
- Persist an optional `[ssh]` table on connection files and expose the same fields in the Postgres wizard.
- Keep saved `host`/`port` as the address seen from the bastion; rewrite to `127.0.0.1` only at connect/test time.

## Test plan
- [ ] Create a Postgres connection with SSH tunnel on: bastion host/user, optional key path (empty → agent), Test then Connect.
- [ ] Confirm `~/.ssh/known_hosts` is required (unknown host fails with an SSH error, not “cannot reach database”).
- [ ] Save the connection; reopen the file and confirm `[ssh]` is written and secrets stay in `.env`.
- [ ] Edit SSH fields on a live connection and confirm it reconnects.
- [ ] Verify CA / Verify Full through SSH is rejected with the hostname-verify message; Require still works.


Made with [Cursor](https://cursor.com)