### PR TITLE
Fix Release #13: Windows SSH agent + macOS DMG EULA attach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,9 @@ jobs:
           MNT=$(mktemp -d)
           cleanup() { hdiutil detach "$MNT" -quiet 2>/dev/null || true; rmdir "$MNT" 2>/dev/null || true; }
           trap cleanup EXIT
-          hdiutil attach "$DMG" -mountpoint "$MNT" -nobrowse
+          # packager `license-file` is passed as --eula; without Agree on stdin,
+          # hdiutil prints the license and exits with "attach canceled".
+          hdiutil attach "$DMG" -mountpoint "$MNT" -nobrowse <<<'Y'
           APP="$MNT/Based.app"
           if [ ! -d "$APP" ]; then
             echo "::error::Based.app not found at $APP"

--- a/crates/based-ssh/src/tunnel.rs
+++ b/crates/based-ssh/src/tunnel.rs
@@ -171,38 +171,48 @@ async fn authenticate(
     authenticate_with_agent(session, &ssh.user).await
 }
 
-async fn connect_ssh_agent() -> Result<AgentClient<Box<dyn AgentStream + Send + Unpin>>> {
-    #[cfg(unix)]
-    {
-        AgentClient::connect_env()
-            .await
-            .map(AgentClient::dynamic)
-            .context("SSH tunnel: could not connect to ssh-agent (SSH_AUTH_SOCK)")
-    }
-    #[cfg(windows)]
-    {
-        // `connect_env` is Unix-only (SSH_AUTH_SOCK). On Windows prefer the
-        // OpenSSH agent named pipe, then Pageant.
-        match AgentClient::connect_named_pipe(r"\\.\pipe\openssh-ssh-agent").await {
-            Ok(client) => Ok(client.dynamic()),
-            Err(openssh_err) => AgentClient::connect_pageant()
-                .await
-                .map(AgentClient::dynamic)
-                .with_context(|| {
-                    format!(
-                        "SSH tunnel: could not connect to OpenSSH agent \
-                         (\\\\.\\pipe\\openssh-ssh-agent: {openssh_err}) or Pageant"
-                    )
-                }),
-        }
-    }
-}
-
 async fn authenticate_with_agent(
     session: &mut client::Handle<ClientHandler>,
     user: &str,
 ) -> Result<()> {
-    let mut agent = connect_ssh_agent().await?;
+    // Keep concrete agent stream types (do not `.dynamic()`): boxing breaks the
+    // `'static` bound russh's `Signer` impl needs and surfaces as HRTB errors
+    // inside `Tokio::spawn_result` on the Postgres open/test paths.
+    #[cfg(unix)]
+    {
+        let mut agent = AgentClient::connect_env()
+            .await
+            .context("SSH tunnel: could not connect to ssh-agent (SSH_AUTH_SOCK)")?;
+        try_agent_identities(session, user, &mut agent).await
+    }
+    #[cfg(windows)]
+    {
+        // `connect_env` is Unix-only (SSH_AUTH_SOCK). Prefer OpenSSH's agent
+        // named pipe, then Pageant.
+        match AgentClient::connect_named_pipe(r"\\.\pipe\openssh-ssh-agent").await {
+            Ok(mut agent) => try_agent_identities(session, user, &mut agent).await,
+            Err(openssh_err) => {
+                let mut agent = AgentClient::connect_pageant().await.with_context(|| {
+                    format!(
+                        "SSH tunnel: could not connect to OpenSSH agent \
+                             (\\\\.\\pipe\\openssh-ssh-agent: {openssh_err}) or Pageant"
+                    )
+                })?;
+                try_agent_identities(session, user, &mut agent).await
+            }
+        }
+    }
+}
+
+async fn try_agent_identities<S>(
+    session: &mut client::Handle<ClientHandler>,
+    user: &str,
+    agent: &mut AgentClient<S>,
+) -> Result<()>
+where
+    // Matches russh's `Signer` impl on `AgentClient<R>` (private `auth` module).
+    S: AgentStream + Unpin + Send + 'static,
+{
     let identities = agent
         .request_identities()
         .await
@@ -220,7 +230,7 @@ async fn authenticate_with_agent(
     let mut last_err = None;
     for public in identities {
         match session
-            .authenticate_publickey_with(user, public, hash, &mut agent)
+            .authenticate_publickey_with(user, public, hash, agent)
             .await
         {
             Ok(result) if result.success() => return Ok(()),

--- a/crates/based-ssh/src/tunnel.rs
+++ b/crates/based-ssh/src/tunnel.rs
@@ -9,7 +9,7 @@ use based_core::SshTunnelConfig;
 use russh::keys::{HashAlg, PrivateKeyWithHashAlg, PublicKey, load_secret_key};
 use russh::{
     Channel, client,
-    keys::agent::client::AgentClient,
+    keys::agent::client::{AgentClient, AgentStream},
     keys::known_hosts::{check_known_hosts, check_known_hosts_path},
 };
 use tokio::io::{AsyncWriteExt, copy_bidirectional};
@@ -171,13 +171,38 @@ async fn authenticate(
     authenticate_with_agent(session, &ssh.user).await
 }
 
+async fn connect_ssh_agent() -> Result<AgentClient<Box<dyn AgentStream + Send + Unpin>>> {
+    #[cfg(unix)]
+    {
+        AgentClient::connect_env()
+            .await
+            .map(AgentClient::dynamic)
+            .context("SSH tunnel: could not connect to ssh-agent (SSH_AUTH_SOCK)")
+    }
+    #[cfg(windows)]
+    {
+        // `connect_env` is Unix-only (SSH_AUTH_SOCK). On Windows prefer the
+        // OpenSSH agent named pipe, then Pageant.
+        match AgentClient::connect_named_pipe(r"\\.\pipe\openssh-ssh-agent").await {
+            Ok(client) => Ok(client.dynamic()),
+            Err(openssh_err) => AgentClient::connect_pageant()
+                .await
+                .map(AgentClient::dynamic)
+                .with_context(|| {
+                    format!(
+                        "SSH tunnel: could not connect to OpenSSH agent \
+                         (\\\\.\\pipe\\openssh-ssh-agent: {openssh_err}) or Pageant"
+                    )
+                }),
+        }
+    }
+}
+
 async fn authenticate_with_agent(
     session: &mut client::Handle<ClientHandler>,
     user: &str,
 ) -> Result<()> {
-    let mut agent = AgentClient::connect_env()
-        .await
-        .context("SSH tunnel: could not connect to ssh-agent (SSH_AUTH_SOCK)")?;
+    let mut agent = connect_ssh_agent().await?;
     let identities = agent
         .request_identities()
         .await


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[Release run #13](https://github.com/pavi2410/based/actions/runs/32223293591) failed on two platforms (Linux succeeded). This PR fixes both root causes, plus a Clippy HRTB regression from the first Windows agent attempt.

### Windows — compile error in `based-ssh`

```
error[E0599]: no associated function named `connect_env` found for struct `AgentClient<S>`
```

`AgentClient::connect_env()` is Unix-only (`SSH_AUTH_SOCK`). CI does not build Windows; the release matrix does.

**Fix:** connect via `\\.\pipe\openssh-ssh-agent`, then fall back to Pageant — using concrete stream types (no `.dynamic()`).

### macOS — `hdiutil: attach canceled`

Packager `license-file` becomes a DMG EULA (`--eula`). Non-interactive `hdiutil attach` prints the license and cancels.

**Fix:** feed `Y` on stdin when attaching in the verify step.

### Clippy on this PR

The first Windows fix boxed the agent with `.dynamic()`, which dropped the `'static` bound russh’s `Signer` impl needs and surfaced as `higher-ranked lifetime error` at `Tokio::spawn_result` in `apps/desktop/src/postgres/mod.rs`. Follow-up commit keeps concrete agent types per platform.

## Test plan

- [x] `cargo test -p based-ssh`
- [x] `cargo clippy --workspace --all-targets`
- [ ] CI green on this PR
- [ ] Re-run **Release** workflow on `main` after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a018de-1d95-794e-a634-ccf2112cbeed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a018de-1d95-794e-a634-ccf2112cbeed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

