### PR TITLE
Fix Windows Release: russh connect_pageant is not a Result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,22 @@ jobs:
 
       - name: Build desktop
         run: cargo build -p desktop
+
+  # Linux CI never type-checks `#[cfg(windows)]`. The release matrix does, so
+  # SSH-agent Windows APIs have to be checked here or they only fail on Release.
+  windows:
+    name: rust (windows check)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+
+      - name: Check desktop
+        run: cargo check -p desktop

--- a/crates/based-ssh/src/tunnel.rs
+++ b/crates/based-ssh/src/tunnel.rs
@@ -189,16 +189,21 @@ async fn authenticate_with_agent(
     {
         // `connect_env` is Unix-only (SSH_AUTH_SOCK). Prefer OpenSSH's agent
         // named pipe, then Pageant.
+        //
+        // russh 0.54: `connect_named_pipe` returns Result, but `connect_pageant`
+        // returns `AgentClient` (not Result) — do not call `with_context` on it.
         match AgentClient::connect_named_pipe(r"\\.\pipe\openssh-ssh-agent").await {
             Ok(mut agent) => try_agent_identities(session, user, &mut agent).await,
             Err(openssh_err) => {
-                let mut agent = AgentClient::connect_pageant().await.with_context(|| {
-                    format!(
-                        "SSH tunnel: could not connect to OpenSSH agent \
-                             (\\\\.\\pipe\\openssh-ssh-agent: {openssh_err}) or Pageant"
-                    )
-                })?;
-                try_agent_identities(session, user, &mut agent).await
+                let mut agent = AgentClient::connect_pageant().await;
+                try_agent_identities(session, user, &mut agent)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "SSH tunnel: OpenSSH agent unavailable ({openssh_err}); \
+                             Pageant authentication failed"
+                        )
+                    })
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cannot run a real Windows MSVC build in this environment (aws-lc-sys needs `windows.h`). Reviewed everything since the last successful Release (#11) for Windows compile issues.

**Release #14** failed only on Windows:

```
error[E0599]: no method named `with_context` found for struct `AgentClient<S>`
  --> crates/based-ssh/src/tunnel.rs:195
    AgentClient::connect_pageant().await.with_context(|| { ... })
```

In **russh 0.54.5**, `connect_pageant()` is `async fn ... -> Self`, not `Result`. `connect_named_pipe` is the one that returns `Result`. That only compiles on Windows, and Linux CI never type-checks it.

**Fix:** use the Pageant client as `Self`, and attach `with_context` to the later auth `Result`.

**CI:** add `windows-latest` `cargo check -p desktop` so this class of bug fails PRs instead of Release.

Other post-#11 desktop/SSH code looks Windows-safe (paths via `dirs`/`PathBuf`, russh known_hosts already has a Windows `ssh/known_hosts` path). The remaining risk is only uncompiled `#[cfg(windows)]` code, which the new job covers.

## Test plan

- [x] `cargo test -p based-ssh`
- [x] `cargo clippy -p based-ssh --all-targets`
- [ ] CI `rust (windows check)` green on this PR
- [ ] Re-run Release after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a018de-1d95-794e-a634-ccf2112cbeed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a018de-1d95-794e-a634-ccf2112cbeed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

